### PR TITLE
FieldDescription needs to be public

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,11 +1,11 @@
 #[derive(PartialEq, Eq, Debug)]
 pub struct FieldDescription {
-    name: &'static str,
-    asn1_type: &'static str,
-    rust_type: &'static str,
-    tag: FieldTag,
-    optional: bool,
-    default: Option<&'static str>,
+    pub name: &'static str,
+    pub asn1_type: &'static str,
+    pub rust_type: &'static str,
+    pub tag: FieldTag,
+    pub optional: bool,
+    pub default: Option<&'static str>,
 }
 
 #[derive(PartialEq, Eq, Debug)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,5 +1,5 @@
 #[derive(PartialEq, Eq, Debug)]
-struct FieldDescription {
+pub struct FieldDescription {
     name: &'static str,
     asn1_type: &'static str,
     rust_type: &'static str,


### PR DESCRIPTION
Hi Alex,

In order to successfully use the current _Signature_ example in the README.md, the _FieldDescription_ struct and its fields need to be public, otherwise the expansion of the `asn1!` macro will fail.

Easy fix ... although I don't know if this is your intention...

Cheers
Marcus