### PR TITLE
Allow callbacks to return different error types

### DIFF
--- a/examples/no_std.rs
+++ b/examples/no_std.rs
@@ -3,7 +3,7 @@
 fn main() {
     let data = b"\x30\x06\x02\x01\x01\x02\x01\x03";
 
-    let result = asn1::parse(data, |d| {
+    let result: asn1::ParseResult<_> = asn1::parse(data, |d| {
         d.read_element::<asn1::Sequence>()?
             .parse(|d| Ok((d.read_element::<i64>()?, d.read_element::<i64>()?)))
     });

--- a/fuzz/fuzz_targets/fuzz_asn1_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_asn1_parse.rs
@@ -2,7 +2,7 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = asn1::parse(data, |d| {
+    let _: asn1::ParseResult<()> = asn1::parse(data, |d| {
         d.read_element::<()>()?;
         d.read_element::<bool>()?;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -382,7 +382,10 @@ impl<'a> Sequence<'a> {
 
     /// Parses the contents of the `Sequence`. Behaves the same as the module-level `parse`
     /// function.
-    pub fn parse<T, F: Fn(&mut Parser) -> ParseResult<T>>(self, f: F) -> ParseResult<T> {
+    pub fn parse<T, E: From<ParseError>, F: Fn(&mut Parser) -> Result<T, E>>(
+        self,
+        f: F,
+    ) -> Result<T, E> {
         parse(self.data, f)
     }
 }


### PR DESCRIPTION
The one requirement is that they be From<ParseError>.