### PR TITLE
fixes #132 -- fixed building and tests on non-x86 platforms:

### DIFF
--- a/examples/no_std.rs
+++ b/examples/no_std.rs
@@ -10,8 +10,10 @@ fn main() {
 
     // Using libc::printf because println! isn't no_std!
     match result {
-        Ok((r, s)) => unsafe { libc::printf(b"r=%ld, s=%ld\n\x00".as_ptr() as *const i8, r, s) },
-        Err(_) => unsafe { libc::printf("Error\n\x00".as_ptr() as *const i8) },
+        Ok((r, s)) => unsafe {
+            libc::printf(b"r=%ld, s=%ld\n\x00".as_ptr() as *const libc::c_char, r, s)
+        },
+        Err(_) => unsafe { libc::printf("Error\n\x00".as_ptr() as *const libc::c_char) },
     };
 
     let computed = asn1::write(|w| {
@@ -22,7 +24,7 @@ fn main() {
     });
     unsafe {
         libc::printf(
-            "Original length: %ld\nComputed length: %ld\n\x00".as_ptr() as *const i8,
+            "Original length: %ld\nComputed length: %ld\n\x00".as_ptr() as *const libc::c_char,
             data.len() as i64,
             computed.len() as i64,
         );

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -327,7 +327,7 @@ mod tests {
                 b"\x04\x89\x01\x01\x01\x01\x01\x01\x01\x01\x01"
             ),
             (Err(ParseError::ShortData), b"\x04\x03\x01\x02"),
-            (Err(ParseError::ShortData), b"\x04\x86\xff\xff\xff\xff\xff\xff"),
+            (Err(ParseError::ShortData), b"\x04\x83\xff\xff\xff\xff\xff\xff"),
         ]);
     }
 


### PR DESCRIPTION
1) There was a test that only worked on 64-bit platforms
2) the `no_std` example failed to acount for the fact that `char` is signed vs. unsigned on different platforms