### PR TITLE
Bump to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asn1"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Alex Gaynor <alex.gaynor@gmail.com>"]
 repository = "https://github.com/alex/rust-asn1"
 keywords = ["asn1"]
@@ -16,7 +16,7 @@ derive = ["asn1_derive"]
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
-asn1_derive = { path = "asn1_derive/", version = "0.4.2", optional = true }
+asn1_derive = { path = "asn1_derive/", version = "0.5.0", optional = true }
 
 [dev-dependencies]
 libc = "0.2"

--- a/asn1_derive/Cargo.toml
+++ b/asn1_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asn1_derive"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Alex Gaynor <alex.gaynor@gmail.com>"]
 repository = "https://github.com/alex/rust-asn1"
 license = "BSD-3-Clause"


### PR DESCRIPTION
To be released after https://github.com/pyca/cryptography/pull/6059 is reviewed and determined to be ready (modulo rust-asn1 release)