### PR TITLE
Add relaxeddefault attribute

### DIFF
--- a/asn1_derive/src/lib.rs
+++ b/asn1_derive/src/lib.rs
@@ -152,10 +152,11 @@ fn extract_field_properties(attrs: &[syn::Attribute]) -> (OpType, Option<syn::Li
         } else if attr.path.is_ident("default") || attr.path.is_ident("relaxeddefault") {
             if default.is_some() {
                 panic!("Can't specify #[default] or #[relaxeddefault] more than once");
-            }
-            default = Some(attr.parse_args::<syn::Lit>().unwrap());
-            if attr.path.is_ident("relaxeddefault") {
-                relaxed = true;
+            } else {
+                default = Some(attr.parse_args::<syn::Lit>().unwrap());
+                if attr.path.is_ident("relaxeddefault") {
+                    relaxed = true;
+                }
             }
         }
     }

--- a/asn1_derive/src/lib.rs
+++ b/asn1_derive/src/lib.rs
@@ -149,17 +149,14 @@ fn extract_field_properties(attrs: &[syn::Attribute]) -> (OpType, Option<syn::Li
             } else {
                 panic!("Can't specify #[explicit] or #[implicit] more than once")
             }
-        } else if attr.path.is_ident("default") {
+        } else if attr.path.is_ident("default") || attr.path.is_ident("relaxeddefault") {
             if default.is_some() {
                 panic!("Can't specify #[default] or #[relaxeddefault] more than once");
             }
             default = Some(attr.parse_args::<syn::Lit>().unwrap());
-        } else if attr.path.is_ident("relaxeddefault") {
-            if default.is_some() {
-                panic!("Can't specify #[default] or #[relaxeddefault] more than once");
+            if attr.path.is_ident("relaxeddefault") {
+                relaxed = true;
             }
-            default = Some(attr.parse_args::<syn::Lit>().unwrap());
-            relaxed = true;
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,16 @@ pub fn from_optional_default<T: PartialEq>(v: Option<T>, default: T) -> ParseRes
     }
 }
 
+/// Decodes an `OPTIONAL` ASN.1 value which has a `DEFAULT`. Unlike
+/// [`from_optional_default`] parsing doesn't fail when value is equal to default.
+/// Generaly called immediately after [`Parser::read_element`].
+pub fn from_optional_default_relaxed<T: PartialEq>(v: Option<T>, default: T) -> ParseResult<T> {
+    match v {
+        Some(v) => Ok(v),
+        None => Ok(default),
+    }
+}
+
 /// Prepares an `OPTIONAL` ASN.1 value which has a `DEFAULT` for writing.
 /// Generally called immediately before [`Writer::write_element`].
 pub fn to_optional_default<'a, T: PartialEq>(v: &'a T, default: &'a T) -> Option<&'a T> {


### PR DESCRIPTION
Implement ``[#relaxeddefault(value)]`` attribute. The new attribute
is an alternative to ``[#default(value)]`` that does not fail with
``ParseErrorKind::EncodedDefault`` when a component is encoded with
default value.

DER requires that encoding of a set value or sequence value shall
not include an encoding for any component value which is equal to
its default value. However some systems use BER-like syntax and encode
components with default values. OpenSSL and NSS are more relaxed and
don't fail.

Signed-off-by: Christian Heimes <christian@python.org>