### PR TITLE
Refactor tag to store passed bits, rather than just a u8.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -495,6 +495,8 @@ mod tests {
             ),
             (Err(ParseError::new(ParseErrorKind::ShortData)), b"\x04"),
             (Err(ParseError::new(ParseErrorKind::ShortData)), b""),
+            (Err(ParseError::new(ParseErrorKind::InvalidTag)), b"\x1f"),
+            (Err(ParseError::new(ParseErrorKind::InvalidTag)), b"\xff"),
         ]);
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,6 +7,9 @@ use core::fmt;
 pub enum ParseErrorKind {
     /// Something about the value was invalid.
     InvalidValue,
+    /// Something about the tag was invalid. This refers to a syntax error,
+    /// not a tag's value being unexpected.
+    InvalidTag,
     /// An unexpected tag was encountered.
     UnexpectedTag { actual: Tag },
     /// There was not enough data available to complete parsing.
@@ -108,8 +111,9 @@ impl fmt::Display for ParseError {
         write!(f, "ASN.1 parsing error: ")?;
         match self.kind {
             ParseErrorKind::InvalidValue => write!(f, "invalid value"),
+            ParseErrorKind::InvalidTag => write!(f, "invalid tag"),
             ParseErrorKind::UnexpectedTag { actual } => {
-                write!(f, "unexpected tag (got {})", actual.0)
+                write!(f, "unexpected tag (got {:?})", actual)
             }
             ParseErrorKind::ShortData => write!(f, "short data"),
             ParseErrorKind::IntegerOverflow => write!(f, "integer overflow"),
@@ -171,11 +175,11 @@ impl<'a> Parser<'a> {
     }
 
     pub(crate) fn peek_tag(&mut self) -> Option<Tag> {
-        Some(Tag(*self.data.first()?))
+        Tag::from_u8(*self.data.first()?)
     }
 
     pub(crate) fn read_tag(&mut self) -> ParseResult<Tag> {
-        Ok(Tag(self.read_u8()?))
+        Tag::from_u8(self.read_u8()?).ok_or_else(|| ParseError::new(ParseErrorKind::InvalidTag))
     }
 
     #[inline]
@@ -403,7 +407,7 @@ mod tests {
                 })
                 .add_location(ParseLocation::Index(12))
                 .add_location(ParseLocation::Field("Abc::123")),
-                "ASN.1 parsing error: unexpected tag (got 12)",
+                "ASN.1 parsing error: unexpected tag (got Tag { value: 12, constructed: false, class: Universal })",
             ),
         ]
         .iter()

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -1,19 +1,51 @@
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum TagClass {
     Universal = 0b00,
-    // Application = 0b01,
+    Application = 0b01,
     ContextSpecific = 0b10,
-    // Private = 0b11,
+    Private = 0b11,
 }
 
-// TODO: stop making the internals pub(crate).
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct Tag(pub(crate) u8);
+pub struct Tag {
+    value: u8,
+    constructed: bool,
+    class: TagClass,
+}
 
 pub(crate) const CONSTRUCTED: u8 = 0x20;
 
 impl Tag {
+    // TODO: update API to support long-form tags.
+    pub(crate) fn from_u8(tag: u8) -> Option<Tag> {
+        let value = tag & 0x1f;
+        let constructed = tag & CONSTRUCTED == CONSTRUCTED;
+        let class = match tag >> 6 {
+            0b00 => TagClass::Universal,
+            0b01 => TagClass::Application,
+            0b10 => TagClass::ContextSpecific,
+            0b11 => TagClass::Private,
+            _ => unreachable!(),
+        };
+
+        // Long form, not yet supported.
+        if value == 0x1f {
+            return None;
+        }
+
+        Some(Tag {
+            value,
+            constructed,
+            class,
+        })
+    }
+
     pub(crate) const fn new(tag: u8, class: TagClass, constructed: bool) -> Tag {
-        Tag(tag | ((class as u8) << 6) | (if constructed { CONSTRUCTED } else { 0 }))
+        Tag {
+            value: tag,
+            constructed,
+            class,
+        }
     }
 
     /// This is `pub` for use in tests but is not considered part of the
@@ -27,7 +59,12 @@ impl Tag {
         Tag::new(tag, TagClass::Universal, true)
     }
 
+    // TODO: update API to support long-form tags.
+    pub(crate) const fn as_u8(&self) -> u8 {
+        self.value | ((self.class as u8) << 6) | (if self.constructed { CONSTRUCTED } else { 0 })
+    }
+
     pub(crate) const fn is_constructed(&self) -> bool {
-        (self.0 & CONSTRUCTED) == CONSTRUCTED
+        self.constructed
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -85,7 +85,7 @@ impl Writer<'_> {
     /// TLV is automatically computed.
     #[inline]
     pub fn write_tlv<F: FnOnce(&mut Vec<u8>)>(&mut self, tag: Tag, body: F) {
-        self.data.push(tag.0);
+        self.data.push(tag.as_u8());
         // Push a 0-byte placeholder for the length. Needing only a single byte
         // for the element is probably the most common case.
         self.data.push(0);


### PR DESCRIPTION
This is in preperation for supporting long-form tags