### PR TITLE
Make OwnedBitString parseable, in addition to writable

### DIFF
--- a/src/bit_string.rs
+++ b/src/bit_string.rs
@@ -43,7 +43,8 @@ impl<'a> BitString<'a> {
     }
 }
 
-/// Represents an ASN.1 `BIT STRING` whose contents owned.
+/// Represents an ASN.1 `BIT STRING` whose contents owned. When used to parse
+/// data this will allocate.
 #[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub struct OwnedBitString {
     data: Vec<u8>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -323,9 +323,9 @@ mod tests {
     use crate::types::Asn1Readable;
     use crate::{
         BMPString, BigInt, BigUint, BitString, Choice1, Choice2, Choice3, Enumerated,
-        GeneralizedTime, IA5String, ObjectIdentifier, ParseError, ParseErrorKind, ParseLocation,
-        ParseResult, PrintableString, Sequence, SequenceOf, SetOf, Tag, Tlv, UniversalString,
-        UtcTime, Utf8String, VisibleString,
+        GeneralizedTime, IA5String, ObjectIdentifier, OwnedBitString, ParseError, ParseErrorKind,
+        ParseLocation, ParseResult, PrintableString, Sequence, SequenceOf, SetOf, Tag, Tlv,
+        UniversalString, UtcTime, Utf8String, VisibleString,
     };
     #[cfg(feature = "const-generics")]
     use crate::{Explicit, Implicit};
@@ -836,6 +836,41 @@ mod tests {
             (Ok(BitString::new(b"\x80", 7).unwrap()), b"\x03\x02\x07\x80"),
             (
                 Ok(BitString::new(b"\x81\xf0", 4).unwrap()),
+                b"\x03\x03\x04\x81\xf0",
+            ),
+            (
+                Err(ParseError::new(ParseErrorKind::InvalidValue)),
+                b"\x03\x00",
+            ),
+            (
+                Err(ParseError::new(ParseErrorKind::InvalidValue)),
+                b"\x03\x02\x07\x01",
+            ),
+            (
+                Err(ParseError::new(ParseErrorKind::InvalidValue)),
+                b"\x03\x02\x07\x40",
+            ),
+            (
+                Err(ParseError::new(ParseErrorKind::InvalidValue)),
+                b"\x03\x02\x08\x00",
+            ),
+        ]);
+    }
+
+    #[test]
+    fn test_parse_owned_bit_string() {
+        assert_parses::<OwnedBitString>(&[
+            (Ok(OwnedBitString::new(vec![], 0).unwrap()), b"\x03\x01\x00"),
+            (
+                Ok(OwnedBitString::new(vec![0x00], 7).unwrap()),
+                b"\x03\x02\x07\x00",
+            ),
+            (
+                Ok(OwnedBitString::new(vec![0x80], 7).unwrap()),
+                b"\x03\x02\x07\x80",
+            ),
+            (
+                Ok(OwnedBitString::new(vec![0x81, 0xf0], 4).unwrap()),
                 b"\x03\x03\x04\x81\xf0",
             ),
             (

--- a/src/types.rs
+++ b/src/types.rs
@@ -662,6 +662,13 @@ impl<'a> SimpleAsn1Writable<'a> for BitString<'a> {
         dest.extend_from_slice(self.as_bytes());
     }
 }
+impl<'a> SimpleAsn1Readable<'a> for OwnedBitString {
+    const TAG: Tag = Tag::primitive(0x03);
+    fn parse_data(data: &'a [u8]) -> ParseResult<OwnedBitString> {
+        let bs = BitString::parse_data(data)?;
+        Ok(OwnedBitString::new(bs.as_bytes().to_vec(), bs.padding_bits()).unwrap())
+    }
+}
 impl<'a> SimpleAsn1Writable<'a> for OwnedBitString {
     const TAG: Tag = Tag::primitive(0x03);
     fn write_data(&self, dest: &mut Vec<u8>) {


### PR DESCRIPTION
Finishes coverage on `bit_string.rs`. Refs #274