### PR TITLE
specify chrono 0.4.20 as our minimum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ const-generics = []
 derive = ["asn1_derive"]
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["alloc"] }
+chrono = { version = "0.4.20", default-features = false, features = ["alloc"] }
 asn1_derive = { path = "asn1_derive/", version = "0.10.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
because of a RUSTSEC fix (though one that doesn't impact our usage)