### PR TITLE
Improve fuzzing to check for round-tripping

### DIFF
--- a/fuzz/fuzz_targets/fuzz_asn1_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_asn1_parse.rs
@@ -1,7 +1,7 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-#[derive(asn1::Asn1Read, asn1::Asn1Write)]
+#[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq)]
 struct Data<'a> {
     f1: (),
     f2: bool,
@@ -38,6 +38,8 @@ fuzz_target!(|data: &[u8]| {
         // as `data`, which should hold in general... but it doesn't hold
         // for our UtcTime/GeneralizedTime types. Those types can parse
         // several formats, but always serialize to the same one.
-        let _ = asn1::write_single(&parsed);
+        let written = asn1::write_single(&parsed).unwrap();
+        let reparsed = asn1::parse_single::<Data>(&written).unwrap();
+        assert!(parsed == reparsed);
     }
 });

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1286,6 +1286,10 @@ mod tests {
                 Err(ParseError::new(ParseErrorKind::InvalidValue)),
                 b"\x18\x11-1\n110723459+1002",
             ),
+            (
+                Err(ParseError::new(ParseErrorKind::InvalidValue)),
+                b"\x18\x0d0 1204000060Z",
+            ),
         ]);
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -791,7 +791,9 @@ pub struct GeneralizedTime(chrono::DateTime<chrono::Utc>);
 
 impl GeneralizedTime {
     pub fn new(v: chrono::DateTime<chrono::Utc>) -> ParseResult<GeneralizedTime> {
-        if v.year() < 0 {
+        // Reject leap seconds, which aren't allowed by ASN.1. chrono encodes
+        // them as nanoseconds == 1000000.
+        if v.year() < 0 || v.nanosecond() >= 1_000_000 {
             return Err(ParseError::new(ParseErrorKind::InvalidValue));
         }
         Ok(GeneralizedTime(v))


### PR DESCRIPTION
And fix a case where GeneralizedTime would parse leap seconds