### PR TITLE
Address a new clippy error by shrinking ParseError

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -41,7 +41,7 @@ pub enum ParseLocation {
 #[derive(PartialEq, Eq)]
 pub struct ParseError {
     kind: ParseErrorKind,
-    parse_locations: [Option<ParseLocation>; 8],
+    parse_locations: [Option<ParseLocation>; 4],
     parse_depth: u8,
 }
 
@@ -49,7 +49,7 @@ impl ParseError {
     pub fn new(kind: ParseErrorKind) -> ParseError {
         ParseError {
             kind,
-            parse_locations: [None, None, None, None, None, None, None, None],
+            parse_locations: [None, None, None, None],
             parse_depth: 0,
         }
     }


### PR DESCRIPTION
This means we keep a shorter 'backtrace' for which element failed to parse. I think 4 is probably sufficient? The other solution is to put the `parse_location` inside of a `Box`, but that means allocating, which we've avoided thus far for parsing.