### PR TITLE
Several improvements from fuzzing:

### DIFF
--- a/fuzz/fuzz_targets/fuzz_asn1_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_asn1_parse.rs
@@ -46,11 +46,11 @@ enum Data<'a> {
     #[explicit(9)]
     SequenceOf(asn1::SequenceOf<'a, i64>),
     #[explicit(10)]
-    Struct(StructData),
+    Struct(StructData<'a>),
 }
 
 #[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq)]
-struct StructData {
+struct StructData<'a> {
     f1: Option<()>,
     f2: asn1::Choice2<bool, i64>,
 
@@ -70,6 +70,9 @@ struct StructData {
     f7: asn1::Implicit<u32, 7>,
     #[cfg(feature = "const-generics")]
     f8: asn1::Explicit<u32, 8>,
+
+    #[explicit(9)]
+    f9: Option<asn1::Tlv<'a>>,
 }
 
 fuzz_target!(|data: &[u8]| {

--- a/src/types.rs
+++ b/src/types.rs
@@ -593,7 +593,7 @@ impl<'a> SimpleAsn1Readable<'a> for BigUint<'a> {
 impl<'a> SimpleAsn1Writable for BigUint<'a> {
     const TAG: Tag = Tag::primitive(0x02);
     fn write_data(&self, dest: &mut WriteBuf) -> WriteResult {
-        dest.push_slice(self.data)
+        dest.push_slice(self.as_bytes())
     }
 }
 
@@ -630,7 +630,7 @@ impl<'a> SimpleAsn1Readable<'a> for BigInt<'a> {
 impl<'a> SimpleAsn1Writable for BigInt<'a> {
     const TAG: Tag = Tag::primitive(0x02);
     fn write_data(&self, dest: &mut WriteBuf) -> WriteResult {
-        dest.push_slice(self.data)
+        dest.push_slice(self.as_bytes())
     }
 }
 
@@ -908,7 +908,7 @@ impl SimpleAsn1Writable for Enumerated {
     const TAG: Tag = Tag::primitive(0xa);
 
     fn write_data(&self, dest: &mut WriteBuf) -> WriteResult {
-        u32::write_data(&self.0, dest)
+        u32::write_data(&self.value(), dest)
     }
 }
 


### PR DESCRIPTION
- Include a raw Tlv parse (gets coverage of large tags)
- Use public accessors rather than internal data