### PR TITLE
Properly reject base128 integers with leading 0x80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asn1"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Alex Gaynor <alex.gaynor@gmail.com>"]
 repository = "https://github.com/alex/rust-asn1"
 keywords = ["asn1"]
@@ -17,7 +17,7 @@ derive = ["asn1_derive"]
 
 [dependencies]
 chrono = { version = "0.4.20", default-features = false, features = ["alloc"] }
-asn1_derive = { path = "asn1_derive/", version = "0.12.0", optional = true }
+asn1_derive = { path = "asn1_derive/", version = "0.12.1", optional = true }
 
 [dev-dependencies]
 libc = "0.2.11"

--- a/asn1_derive/Cargo.toml
+++ b/asn1_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asn1_derive"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Alex Gaynor <alex.gaynor@gmail.com>"]
 repository = "https://github.com/alex/rust-asn1"
 license = "BSD-3-Clause"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -573,6 +573,11 @@ mod tests {
                 Err(ParseError::new(ParseErrorKind::InvalidTag)),
                 b"\x1f\x1e\x00",
             ),
+            (
+                // base128 integer with leading 0
+                Err(ParseError::new(ParseErrorKind::InvalidTag)),
+                b"\xff\x80\x84\x01\x01\xa9",
+            ),
         ]);
     }
 


### PR DESCRIPTION
Caught by the fuzzer