### PR TITLE
Impl std::error::Error for WriteError

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -730,4 +730,9 @@ mod tests {
             (Box::new(0), b"\x02\x01\x00"),
         ]);
     }
+
+    #[test]
+    fn test_write_error_display() {
+        assert_eq!(&WriteError::AllocationError.to_string(), "allocation error");
+    }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,7 +1,7 @@
 use crate::types::{Asn1Writable, SimpleAsn1Writable};
 use crate::Tag;
-use alloc::vec;
 use alloc::vec::Vec;
+use alloc::{fmt, vec};
 
 /// `WriteError` are returned when there is an error writing the ASN.1 data.
 ///
@@ -13,6 +13,17 @@ use alloc::vec::Vec;
 pub enum WriteError {
     AllocationError,
 }
+
+impl fmt::Display for WriteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WriteError::AllocationError => write!(f, "allocation error"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for WriteError {}
 
 pub type WriteResult<T = ()> = Result<T, WriteError>;
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -733,6 +733,7 @@ mod tests {
 
     #[test]
     fn test_write_error_display() {
+        use alloc::string::ToString;
         assert_eq!(&WriteError::AllocationError.to_string(), "allocation error");
     }
 }


### PR DESCRIPTION
Closes #347 