### PR TITLE
Draft: New Feature: Define application tags from outside.

### DIFF
--- a/asn1_derive/src/lib.rs
+++ b/asn1_derive/src/lib.rs
@@ -317,11 +317,11 @@ fn generate_read_element(
                 TagClass::Application => {
                     if arg.required {
                         quote::quote! {
-                            p.read_explicit_element_application(#value)#add_error_location?
+                            p.read_explicit_application_element(#value)#add_error_location?
                         }
                     } else {
                         quote::quote! {
-                            p.read_optional_explicit_element_application(#value)#add_error_location?
+                            p.read_optional_explicit_application_element(#value)#add_error_location?
                         }
                     }
                 }
@@ -344,11 +344,11 @@ fn generate_read_element(
                 TagClass::Application => {
                     if arg.required {
                         quote::quote! {
-                            p.read_implicit_element_application(#value)#add_error_location?
+                            p.read_implicit_application_element(#value)#add_error_location?
                         }
                     } else {
                         quote::quote! {
-                            p.read_optional_implicit_element_application(#value)#add_error_location?
+                            p.read_optional_implicit_application_element(#value)#add_error_location?
                         }
                     }
                 }
@@ -561,11 +561,11 @@ fn generate_write_element(
                 TagClass::Application => {
                     if arg.required {
                         quote::quote_spanned! {f.span() =>
-                            w.write_explicit_element_application(#field_read, #value)?;
+                            w.write_explicit_application_element(#field_read, #value)?;
                         }
                     } else {
                         quote::quote_spanned! {f.span() =>
-                            w.write_optional_explicit_element_application(#field_read, #value)?;
+                            w.write_optional_explicit_application_element(#field_read, #value)?;
                         }
                     }
                 }

--- a/asn1_derive/src/lib.rs
+++ b/asn1_derive/src/lib.rs
@@ -228,7 +228,7 @@ enum OpType {
 struct OpTypeArgs {
     value: proc_macro2::Literal,
     required: bool,
-    tagclass: TagClass,
+    tag_class: TagClass,
 }
 
 fn parse_tag_class_from_ident(ident: &str) -> Option<TagClass> {
@@ -265,7 +265,7 @@ impl syn::parse::Parse for OpTypeArgs {
 
         Ok(OpTypeArgs {
             value,
-            tagclass,
+            tag_class: tagclass,
             required,
         })
     }
@@ -313,15 +313,15 @@ fn generate_read_element(
     let mut read_op = match read_type {
         OpType::Explicit(arg) => {
             let value = arg.value;
-            match arg.tagclass {
+            match arg.tag_class {
                 TagClass::Application => {
                     if arg.required {
                         quote::quote! {
-                            p.read_explicit_application_element(#value)#add_error_location?
+                            p.read_explicit_class_element(#value, TagClass::Application)#add_error_location?
                         }
                     } else {
                         quote::quote! {
-                            p.read_optional_explicit_application_element(#value)#add_error_location?
+                            p.read_optional_explicit_class_element(#value, TagClass::Application)#add_error_location?
                         }
                     }
                 }
@@ -340,15 +340,15 @@ fn generate_read_element(
         }
         OpType::Implicit(arg) => {
             let value = arg.value;
-            match arg.tagclass {
+            match arg.tag_class {
                 TagClass::Application => {
                     if arg.required {
                         quote::quote! {
-                            p.read_implicit_application_element(#value)#add_error_location?
+                            p.read_implicit_class_element(#value, TagClass::Application)#add_error_location?
                         }
                     } else {
                         quote::quote! {
-                            p.read_optional_implicit_application_element(#value)#add_error_location?
+                            p.read_optional_implicit_class_element(#value, TagClass::Application)#add_error_location?
                         }
                     }
                 }
@@ -557,15 +557,16 @@ fn generate_write_element(
     match write_type {
         OpType::Explicit(arg) => {
             let value = arg.value;
-            match arg.tagclass {
+            let tag_class = arg.tag_class;
+            match tag_class {
                 TagClass::Application => {
                     if arg.required {
                         quote::quote_spanned! {f.span() =>
-                            w.write_explicit_application_element(#field_read, #value)?;
+                            w.write_explicit_class_element(#field_read, #value, TagClass::Application)?;
                         }
                     } else {
                         quote::quote_spanned! {f.span() =>
-                            w.write_optional_explicit_application_element(#field_read, #value)?;
+                            w.write_optional_explicit_class_element(#field_read, #value, TagClass::Application)?;
                         }
                     }
                 }
@@ -584,15 +585,15 @@ fn generate_write_element(
         }
         OpType::Implicit(arg) => {
             let value = arg.value;
-            match arg.tagclass {
+            match arg.tag_class {
                 TagClass::Application => {
                     if arg.required {
                         quote::quote_spanned! {f.span() =>
-                            w.write_implicit_application_element(#field_read, #value)?;
+                            w.write_implicit_class_element(#field_read, #value, TagClass::Application)?;
                         }
                     } else {
                         quote::quote_spanned! {f.span() =>
-                            w.write_optional_implicit_application_element(#field_read, #value)?;
+                            w.write_optional_implicit_class_element(#field_read, #value, TagClass::Application)?;
                         }
                     }
                 }

--- a/asn1_derive/src/lib.rs
+++ b/asn1_derive/src/lib.rs
@@ -299,20 +299,36 @@ fn generate_read_element(
     let mut read_op = match read_type {
         OpType::Explicit(arg) => {
             let value = arg.value;
-            if arg.required {
-                quote::quote! {
-                    p.read_explicit_element(#value)#add_error_location?
+            let tag_class = tag_class_from_literal(&arg.tagclass);
+            match tag_class {
+                TagClass::Application => {
+                    if arg.required {
+                        quote::quote! {
+                            p.read_explicit_element_application(#value)#add_error_location?
+                        }
+                    } else {
+                        quote::quote! {
+                            p.read_optional_explicit_element_application(#value)#add_error_location?
+                        }
+                    }
                 }
-            } else {
-                quote::quote! {
-                    p.read_optional_explicit_element(#value)#add_error_location?
+                _ => {
+                    if arg.required {
+                        quote::quote! {
+                            p.read_explicit_element(#value)#add_error_location?
+                        }
+                    } else {
+                        quote::quote! {
+                            p.read_optional_explicit_element(#value)#add_error_location?
+                        }
+                    }
                 }
             }
         }
         OpType::Implicit(arg) => {
             let value = arg.value;
-            let tag_class_num = tag_class_from_literal(&arg.tagclass);
-            match tag_class_num {
+            let tag_class = tag_class_from_literal(&arg.tagclass);
+            match tag_class {
                 TagClass::Application => {
                     if arg.required {
                         quote::quote! {
@@ -529,20 +545,36 @@ fn generate_write_element(
     match write_type {
         OpType::Explicit(arg) => {
             let value = arg.value;
-            if arg.required {
-                quote::quote_spanned! {f.span() =>
-                    w.write_explicit_element(#field_read, #value)?;
+            let tag_class = tag_class_from_literal(&arg.tagclass);
+            match tag_class {
+                TagClass::Application => {
+                    if arg.required {
+                        quote::quote_spanned! {f.span() =>
+                            w.write_explicit_element_application(#field_read, #value)?;
+                        }
+                    } else {
+                        quote::quote_spanned! {f.span() =>
+                            w.write_optional_explicit_element_application(#field_read, #value)?;
+                        }
+                    }
                 }
-            } else {
-                quote::quote_spanned! {f.span() =>
-                    w.write_optional_explicit_element(#field_read, #value)?;
+                _ => {
+                    if arg.required {
+                        quote::quote_spanned! {f.span() =>
+                            w.write_explicit_element(#field_read, #value)?;
+                        }
+                    } else {
+                        quote::quote_spanned! {f.span() =>
+                            w.write_optional_explicit_element(#field_read, #value)?;
+                        }
+                    }
                 }
             }
         }
         OpType::Implicit(arg) => {
             let value = arg.value;
-            let tag_class_num = tag_class_from_literal(&arg.tagclass);
-            match tag_class_num {
+            let tag_class = tag_class_from_literal(&arg.tagclass);
+            match tag_class {
                 TagClass::Application => {
                     if arg.required {
                         quote::quote_spanned! {f.span() =>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ pub use crate::object_identifier::ObjectIdentifier;
 pub use crate::parser::{
     parse, parse_single, ParseError, ParseErrorKind, ParseLocation, ParseResult, Parser,
 };
-pub use crate::tag::Tag;
+pub use crate::tag::{Tag, TagClass};
 pub use crate::types::{
     Asn1DefinedByReadable, Asn1DefinedByWritable, Asn1Readable, Asn1Writable, BMPString, BigInt,
     BigUint, Choice1, Choice2, Choice3, DateTime, DefinedByMarker, Enumerated, Explicit,
@@ -187,9 +187,17 @@ pub fn to_optional_default<'a, T: PartialEq>(v: &'a T, default: &'a T) -> Option
 /// considered a part of the supported API surface.
 #[doc(hidden)]
 pub const fn implicit_tag(tag: u32, inner_tag: Tag) -> Tag {
+    const CONTEXT_SPECIFIC_INDEX: u8 = 2u8;
+    implicit_tag_class::<CONTEXT_SPECIFIC_INDEX>(tag, inner_tag)
+}
+
+/// This API is public so that it may be used from macros, but should not be
+/// considered a part of the supported API surface.
+#[doc(hidden)]
+pub const fn implicit_tag_class<const TAG_CLASS: u8>(tag: u32, inner_tag: Tag) -> Tag {
     Tag::new(
         tag,
-        tag::TagClass::ContextSpecific,
+        TagClass::from_u8(TAG_CLASS),
         inner_tag.is_constructed(),
     )
 }
@@ -197,8 +205,16 @@ pub const fn implicit_tag(tag: u32, inner_tag: Tag) -> Tag {
 /// This API is public so that it may be used from macros, but should not be
 /// considered a part of the supported API surface.
 #[doc(hidden)]
+pub const fn explicit_tag_class<const TAG_CLASS: u8>(tag: u32) -> Tag {
+    Tag::new(tag, TagClass::from_u8(TAG_CLASS), true)
+}
+
+/// This API is public so that it may be used from macros, but should not be
+/// considered a part of the supported API surface.
+#[doc(hidden)]
 pub const fn explicit_tag(tag: u32) -> Tag {
-    Tag::new(tag, tag::TagClass::ContextSpecific, true)
+    const CONTEXT_SPECIFIC_INDEX: u8 = 2u8;
+    explicit_tag_class::<CONTEXT_SPECIFIC_INDEX>(tag)
 }
 
 /// This API is public so that it may be used from macros, but should not be

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,8 +209,7 @@ pub const fn explicit_tag_class(tag: u32, tag_class: TagClass) -> Tag {
 /// considered a part of the supported API surface.
 #[doc(hidden)]
 pub const fn explicit_tag(tag: u32) -> Tag {
-    const CONTEXT_SPECIFIC_TAG: TagClass = TagClass::ContextSpecific;
-    explicit_tag_class(tag, CONTEXT_SPECIFIC_TAG)
+    explicit_tag_class(tag, TagClass::ContextSpecific)
 }
 
 /// This API is public so that it may be used from macros, but should not be

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,6 @@ pub fn to_optional_default<'a, T: PartialEq>(v: &'a T, default: &'a T) -> Option
 /// This API is public so that it may be used from macros, but should not be
 /// considered a part of the supported API surface.
 #[doc(hidden)]
-#[cfg(feature = "const-generics")]
 pub const fn implicit_tag_class<const TAG_CLASS: u8>(tag: u32, inner_tag: Tag) -> Tag {
     Tag::new(
         tag,
@@ -219,7 +218,6 @@ pub const fn implicit_tag_context_specific(tag: u32, inner_tag: Tag) -> Tag {
 /// This API is public so that it may be used from macros, but should not be
 /// considered a part of the supported API surface.
 #[doc(hidden)]
-#[cfg(feature = "const-generics")]
 pub const fn explicit_tag_class<const TAG_CLASS: u8>(tag: u32) -> Tag {
     Tag::new(tag, TagClass::from_u8(TAG_CLASS), true)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,7 @@ pub use crate::writer::{write, write_single, WriteBuf, WriteError, WriteResult, 
 
 pub use asn1_derive::{oid, Asn1DefinedByRead, Asn1DefinedByWrite, Asn1Read, Asn1Write};
 
-/// Decodes an `OPTIONAL` ASN.1 value which has a `DEFAULT`. Generaly called
+/// Decodes an `OPTIONAL` ASN.1 value which has a `DEFAULT`. Generally called
 /// immediately after [`Parser::read_element`].
 pub fn from_optional_default<T: PartialEq>(v: Option<T>, default: T) -> ParseResult<T> {
     match v {
@@ -186,14 +186,7 @@ pub fn to_optional_default<'a, T: PartialEq>(v: &'a T, default: &'a T) -> Option
 /// This API is public so that it may be used from macros, but should not be
 /// considered a part of the supported API surface.
 #[doc(hidden)]
-pub const fn implicit_tag(tag: u32, inner_tag: Tag) -> Tag {
-    const CONTEXT_SPECIFIC: u8 = TagClass::ContextSpecific as u8;
-    implicit_tag_class::<CONTEXT_SPECIFIC>(tag, inner_tag)
-}
-
-/// This API is public so that it may be used from macros, but should not be
-/// considered a part of the supported API surface.
-#[doc(hidden)]
+#[cfg(feature = "const-generics")]
 pub const fn implicit_tag_class<const TAG_CLASS: u8>(tag: u32, inner_tag: Tag) -> Tag {
     Tag::new(
         tag,
@@ -205,16 +198,60 @@ pub const fn implicit_tag_class<const TAG_CLASS: u8>(tag: u32, inner_tag: Tag) -
 /// This API is public so that it may be used from macros, but should not be
 /// considered a part of the supported API surface.
 #[doc(hidden)]
+pub const fn implicit_tag(tag: u32, inner_tag: Tag) -> Tag {
+    implicit_tag_context_specific(tag, inner_tag)
+}
+
+/// This API is public so that it may be used from macros, but should not be
+/// considered a part of the supported API surface.
+#[doc(hidden)]
+pub const fn implicit_tag_application(tag: u32, inner_tag: Tag) -> Tag {
+    Tag::new(
+        tag,
+        TagClass::Application,
+        inner_tag.is_constructed()
+    )
+}
+
+/// This API is public so that it may be used from macros, but should not be
+/// considered a part of the supported API surface.
+#[doc(hidden)]
+pub const fn implicit_tag_context_specific(tag: u32, inner_tag: Tag) -> Tag {
+    Tag::new(
+        tag,
+        TagClass::ContextSpecific,
+        inner_tag.is_constructed()
+    )
+}
+
+/// This API is public so that it may be used from macros, but should not be
+/// considered a part of the supported API surface.
+#[doc(hidden)]
+#[cfg(feature = "const-generics")]
 pub const fn explicit_tag_class<const TAG_CLASS: u8>(tag: u32) -> Tag {
     Tag::new(tag, TagClass::from_u8(TAG_CLASS), true)
+}
+
+
+/// This API is public so that it may be used from macros, but should not be
+/// considered a part of the supported API surface.
+#[doc(hidden)]
+pub const fn explicit_tag_application(tag: u32) -> Tag {
+    Tag::new(tag, TagClass::Application, true)
+}
+
+/// This API is public so that it may be used from macros, but should not be
+/// considered a part of the supported API surface.
+#[doc(hidden)]
+pub const fn explicit_tag_context_specific(tag: u32) -> Tag {
+    Tag::new(tag, TagClass::ContextSpecific, true)
 }
 
 /// This API is public so that it may be used from macros, but should not be
 /// considered a part of the supported API surface.
 #[doc(hidden)]
 pub const fn explicit_tag(tag: u32) -> Tag {
-    const CONTEXT_SPECIFIC: u8 = TagClass::ContextSpecific as u8;
-    explicit_tag_class::<CONTEXT_SPECIFIC>(tag)
+    explicit_tag_context_specific(tag)
 }
 
 /// This API is public so that it may be used from macros, but should not be

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,22 +206,14 @@ pub const fn implicit_tag(tag: u32, inner_tag: Tag) -> Tag {
 /// considered a part of the supported API surface.
 #[doc(hidden)]
 pub const fn implicit_tag_application(tag: u32, inner_tag: Tag) -> Tag {
-    Tag::new(
-        tag,
-        TagClass::Application,
-        inner_tag.is_constructed()
-    )
+    Tag::new(tag, TagClass::Application, inner_tag.is_constructed())
 }
 
 /// This API is public so that it may be used from macros, but should not be
 /// considered a part of the supported API surface.
 #[doc(hidden)]
 pub const fn implicit_tag_context_specific(tag: u32, inner_tag: Tag) -> Tag {
-    Tag::new(
-        tag,
-        TagClass::ContextSpecific,
-        inner_tag.is_constructed()
-    )
+    Tag::new(tag, TagClass::ContextSpecific, inner_tag.is_constructed())
 }
 
 /// This API is public so that it may be used from macros, but should not be
@@ -231,7 +223,6 @@ pub const fn implicit_tag_context_specific(tag: u32, inner_tag: Tag) -> Tag {
 pub const fn explicit_tag_class<const TAG_CLASS: u8>(tag: u32) -> Tag {
     Tag::new(tag, TagClass::from_u8(TAG_CLASS), true)
 }
-
 
 /// This API is public so that it may be used from macros, but should not be
 /// considered a part of the supported API surface.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,61 +186,31 @@ pub fn to_optional_default<'a, T: PartialEq>(v: &'a T, default: &'a T) -> Option
 /// This API is public so that it may be used from macros, but should not be
 /// considered a part of the supported API surface.
 #[doc(hidden)]
-pub const fn implicit_tag_class<const TAG_CLASS: u8>(tag: u32, inner_tag: Tag) -> Tag {
-    Tag::new(
-        tag,
-        TagClass::from_u8(TAG_CLASS),
-        inner_tag.is_constructed(),
-    )
+pub const fn implicit_tag_class(tag: u32, tag_class: TagClass, inner_tag: Tag) -> Tag {
+    Tag::new(tag, tag_class, inner_tag.is_constructed())
 }
 
 /// This API is public so that it may be used from macros, but should not be
 /// considered a part of the supported API surface.
 #[doc(hidden)]
 pub const fn implicit_tag(tag: u32, inner_tag: Tag) -> Tag {
-    implicit_tag_context_specific(tag, inner_tag)
+    const TAG_CLASS: TagClass = TagClass::ContextSpecific;
+    implicit_tag_class(tag, TAG_CLASS, inner_tag)
 }
 
 /// This API is public so that it may be used from macros, but should not be
 /// considered a part of the supported API surface.
 #[doc(hidden)]
-pub const fn implicit_tag_application(tag: u32, inner_tag: Tag) -> Tag {
-    Tag::new(tag, TagClass::Application, inner_tag.is_constructed())
-}
-
-/// This API is public so that it may be used from macros, but should not be
-/// considered a part of the supported API surface.
-#[doc(hidden)]
-pub const fn implicit_tag_context_specific(tag: u32, inner_tag: Tag) -> Tag {
-    Tag::new(tag, TagClass::ContextSpecific, inner_tag.is_constructed())
-}
-
-/// This API is public so that it may be used from macros, but should not be
-/// considered a part of the supported API surface.
-#[doc(hidden)]
-pub const fn explicit_tag_class<const TAG_CLASS: u8>(tag: u32) -> Tag {
-    Tag::new(tag, TagClass::from_u8(TAG_CLASS), true)
-}
-
-/// This API is public so that it may be used from macros, but should not be
-/// considered a part of the supported API surface.
-#[doc(hidden)]
-pub const fn explicit_tag_application(tag: u32) -> Tag {
-    Tag::new(tag, TagClass::Application, true)
-}
-
-/// This API is public so that it may be used from macros, but should not be
-/// considered a part of the supported API surface.
-#[doc(hidden)]
-pub const fn explicit_tag_context_specific(tag: u32) -> Tag {
-    Tag::new(tag, TagClass::ContextSpecific, true)
+pub const fn explicit_tag_class(tag: u32, tag_class: TagClass) -> Tag {
+    Tag::new(tag, tag_class, true)
 }
 
 /// This API is public so that it may be used from macros, but should not be
 /// considered a part of the supported API surface.
 #[doc(hidden)]
 pub const fn explicit_tag(tag: u32) -> Tag {
-    explicit_tag_context_specific(tag)
+    const CONTEXT_SPECIFIC_TAG: TagClass = TagClass::ContextSpecific;
+    explicit_tag_class(tag, CONTEXT_SPECIFIC_TAG)
 }
 
 /// This API is public so that it may be used from macros, but should not be

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,8 +187,8 @@ pub fn to_optional_default<'a, T: PartialEq>(v: &'a T, default: &'a T) -> Option
 /// considered a part of the supported API surface.
 #[doc(hidden)]
 pub const fn implicit_tag(tag: u32, inner_tag: Tag) -> Tag {
-    const CONTEXT_SPECIFIC_INDEX: u8 = 2u8;
-    implicit_tag_class::<CONTEXT_SPECIFIC_INDEX>(tag, inner_tag)
+    const CONTEXT_SPECIFIC: u8 = TagClass::ContextSpecific as u8;
+    implicit_tag_class::<CONTEXT_SPECIFIC>(tag, inner_tag)
 }
 
 /// This API is public so that it may be used from macros, but should not be
@@ -213,8 +213,8 @@ pub const fn explicit_tag_class<const TAG_CLASS: u8>(tag: u32) -> Tag {
 /// considered a part of the supported API surface.
 #[doc(hidden)]
 pub const fn explicit_tag(tag: u32) -> Tag {
-    const CONTEXT_SPECIFIC_INDEX: u8 = 2u8;
-    explicit_tag_class::<CONTEXT_SPECIFIC_INDEX>(tag)
+    const CONTEXT_SPECIFIC: u8 = TagClass::ContextSpecific as u8;
+    explicit_tag_class::<CONTEXT_SPECIFIC>(tag)
 }
 
 /// This API is public so that it may be used from macros, but should not be

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -301,7 +301,7 @@ impl<'a> Parser<'a> {
 
     /// This is an alias for `read_element::<Explicit<T, tag, 1>>` for use when
     /// MSRV is < 1.51.
-    pub fn read_explicit_element_application<T: Asn1Readable<'a>>(
+    pub fn read_explicit_application_element<T: Asn1Readable<'a>>(
         &mut self,
         tag: u32,
     ) -> ParseResult<T> {
@@ -331,7 +331,7 @@ impl<'a> Parser<'a> {
 
     /// This is an alias for `read_element::<Option<Explicit<T, tag, 1>>>` for use
     /// when MSRV is <1.51.
-    pub fn read_optional_explicit_element_application<T: Asn1Readable<'a>>(
+    pub fn read_optional_explicit_application_element<T: Asn1Readable<'a>>(
         &mut self,
         tag: u32,
     ) -> ParseResult<Option<T>> {
@@ -358,7 +358,7 @@ impl<'a> Parser<'a> {
 
     /// This is an alias for `read_element::<Implicit<T, tag, 1>>` for use when
     /// MSRV is <1.51.
-    pub fn read_implicit_element_application<T: SimpleAsn1Readable<'a>>(
+    pub fn read_implicit_application_element<T: SimpleAsn1Readable<'a>>(
         &mut self,
         tag: u32,
     ) -> ParseResult<T> {
@@ -388,7 +388,7 @@ impl<'a> Parser<'a> {
 
     /// This is an alias for `read_element::<Option<Implicit<T, tag, 1>>>` for use
     /// when MSRV is <1.51.
-    pub fn read_optional_implicit_element_application<T: SimpleAsn1Readable<'a>>(
+    pub fn read_optional_implicit_application_element<T: SimpleAsn1Readable<'a>>(
         &mut self,
         tag: u32,
     ) -> ParseResult<Option<T>> {
@@ -1736,6 +1736,24 @@ mod tests {
             ],
             |p| p.read_optional_implicit_element::<bool>(2),
         );
+
+        assert_parses_cb(
+            &[
+                (Ok(Some(true)), b"\x42\x01\xff"),
+                (Ok(Some(false)), b"\x42\x01\x00"),
+                (Ok(None), b""),
+                (
+                    Err(ParseError::new(ParseErrorKind::ExtraData)),
+                    b"\x01\x01\xff",
+                ),
+                (
+                    Err(ParseError::new(ParseErrorKind::ExtraData)),
+                    b"\x02\x01\xff",
+                ),
+            ],
+            |p| p.read_optional_implicit_application_element::<bool>(2),
+        );
+
         assert_parses_cb(
             &[
                 (Ok(Some(Sequence::new(b"abc"))), b"\xa2\x03abc"),
@@ -1751,6 +1769,23 @@ mod tests {
                 ),
             ],
             |p| p.read_optional_implicit_element::<Sequence>(2),
+        );
+
+        assert_parses_cb(
+            &[
+                (Ok(Some(Sequence::new(b"abc"))), b"\x62\x03abc"),
+                (Ok(Some(Sequence::new(b""))), b"\x62\x00"),
+                (Ok(None), b""),
+                (
+                    Err(ParseError::new(ParseErrorKind::ExtraData)),
+                    b"\x01\x01\xff",
+                ),
+                (
+                    Err(ParseError::new(ParseErrorKind::ExtraData)),
+                    b"\x02\x01\xff",
+                ),
+            ],
+            |p| p.read_optional_implicit_application_element::<Sequence>(2),
         );
 
         assert_parses_cb(
@@ -1837,6 +1872,25 @@ mod tests {
                 ),
             ],
             |p| p.read_optional_explicit_element::<bool>(2),
+        );
+
+        assert_parses_cb(
+            &[
+                (Ok(Some(true)), b"\x62\x03\x01\x01\xff"),
+                (Ok(Some(false)), b"\x62\x03\x01\x01\x00"),
+                (Ok(None), b""),
+                (
+                    Err(ParseError::new(ParseErrorKind::ExtraData)),
+                    b"\x01\x01\xff",
+                ),
+                (
+                    Err(ParseError::new(ParseErrorKind::UnexpectedTag {
+                        actual: Tag::primitive(0x03),
+                    })),
+                    b"\x62\x03\x03\x01\xff",
+                ),
+            ],
+            |p| p.read_optional_explicit_application_element::<bool>(2),
         );
 
         assert_parses_cb(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,5 @@
 use crate::types::{Asn1Readable, SimpleAsn1Readable, Tlv};
-use crate::Tag;
+use crate::{Tag, TagClass};
 use core::fmt;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -299,11 +299,12 @@ impl<'a> Parser<'a> {
     }
 
     /// This is an alias for `read_element::<Explicit<T, tag, 1>>`
-    pub fn read_explicit_application_element<T: Asn1Readable<'a>>(
+    pub fn read_explicit_class_element<T: Asn1Readable<'a>>(
         &mut self,
         tag: u32,
+        tag_class: TagClass,
     ) -> ParseResult<T> {
-        let expected_tag = crate::explicit_tag_application(tag);
+        let expected_tag = crate::explicit_tag_class(tag, tag_class);
         let tlv = self.read_tlv()?;
         if tlv.tag != expected_tag {
             return Err(ParseError::new(ParseErrorKind::UnexpectedTag {
@@ -327,11 +328,12 @@ impl<'a> Parser<'a> {
     }
 
     /// This is an alias for `read_element::<Option<Explicit<T, tag, 1>>>`
-    pub fn read_optional_explicit_application_element<T: Asn1Readable<'a>>(
+    pub fn read_optional_explicit_class_element<T: Asn1Readable<'a>>(
         &mut self,
         tag: u32,
+        tag_class: TagClass,
     ) -> ParseResult<Option<T>> {
-        let expected_tag = crate::explicit_tag_application(tag);
+        let expected_tag = crate::explicit_tag_class(tag, tag_class);
         if self.peek_tag() != Some(expected_tag) {
             return Ok(None);
         }
@@ -352,11 +354,12 @@ impl<'a> Parser<'a> {
     }
 
     /// This is an alias for `read_element::<Implicit<T, tag, 1>>`
-    pub fn read_implicit_application_element<T: SimpleAsn1Readable<'a>>(
+    pub fn read_implicit_class_element<T: SimpleAsn1Readable<'a>>(
         &mut self,
         tag: u32,
+        tag_class: TagClass,
     ) -> ParseResult<T> {
-        let expected_tag = crate::implicit_tag_application(tag, T::TAG);
+        let expected_tag = crate::implicit_tag_class(tag, tag_class, T::TAG);
         let tlv = self.read_tlv()?;
         if tlv.tag != expected_tag {
             return Err(ParseError::new(ParseErrorKind::UnexpectedTag {
@@ -380,11 +383,12 @@ impl<'a> Parser<'a> {
     }
 
     /// This is an alias for `read_element::<Option<Implicit<T, tag, 1>>>`
-    pub fn read_optional_implicit_application_element<T: SimpleAsn1Readable<'a>>(
+    pub fn read_optional_implicit_class_element<T: SimpleAsn1Readable<'a>>(
         &mut self,
         tag: u32,
+        tag_class: TagClass,
     ) -> ParseResult<Option<T>> {
-        let expected_tag = crate::implicit_tag_application(tag, T::TAG);
+        let expected_tag = crate::implicit_tag_class(tag, tag_class, T::TAG);
         if self.peek_tag() != Some(expected_tag) {
             return Ok(None);
         }
@@ -1743,7 +1747,7 @@ mod tests {
                     b"\x02\x01\xff",
                 ),
             ],
-            |p| p.read_optional_implicit_application_element::<bool>(2),
+            |p| p.read_optional_implicit_class_element::<bool>(2, TagClass::Application),
         );
 
         assert_parses_cb(
@@ -1777,7 +1781,7 @@ mod tests {
                     b"\x02\x01\xff",
                 ),
             ],
-            |p| p.read_optional_implicit_application_element::<Sequence>(2),
+            |p| p.read_optional_implicit_class_element::<Sequence>(2, TagClass::Application),
         );
 
         assert_parses_cb(
@@ -1882,7 +1886,7 @@ mod tests {
                     b"\x62\x03\x03\x01\xff",
                 ),
             ],
-            |p| p.read_optional_explicit_application_element::<bool>(2),
+            |p| p.read_optional_explicit_class_element::<bool>(2, TagClass::Application),
         );
 
         assert_parses_cb(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -298,7 +298,7 @@ impl<'a> Parser<'a> {
         parse_single(tlv.data())
     }
 
-    /// This is an alias for `read_element::<Explicit<T, tag, 1>>`
+    /// This is an alias for `read_element::<Explicit<T, tag, tag_class>>`
     pub fn read_explicit_class_element<T: Asn1Readable<'a>>(
         &mut self,
         tag: u32,
@@ -327,7 +327,7 @@ impl<'a> Parser<'a> {
         Ok(Some(parse_single::<T>(tlv.data())?))
     }
 
-    /// This is an alias for `read_element::<Option<Explicit<T, tag, 1>>>`
+    /// This is an alias for `read_element::<Option<Explicit<T, tag, tag_class>>>`
     pub fn read_optional_explicit_class_element<T: Asn1Readable<'a>>(
         &mut self,
         tag: u32,
@@ -353,7 +353,7 @@ impl<'a> Parser<'a> {
         T::parse_data(tlv.data())
     }
 
-    /// This is an alias for `read_element::<Implicit<T, tag, 1>>`
+    /// This is an alias for `read_element::<Implicit<T, tag, tag_class>>`
     pub fn read_implicit_class_element<T: SimpleAsn1Readable<'a>>(
         &mut self,
         tag: u32,
@@ -382,7 +382,7 @@ impl<'a> Parser<'a> {
         Ok(Some(T::parse_data(tlv.data())?))
     }
 
-    /// This is an alias for `read_element::<Option<Implicit<T, tag, 1>>>`
+    /// This is an alias for `read_element::<Option<Implicit<T, tag, tag_class>>>`
     pub fn read_optional_implicit_class_element<T: SimpleAsn1Readable<'a>>(
         &mut self,
         tag: u32,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -286,8 +286,7 @@ impl<'a> Parser<'a> {
         T::parse(self)
     }
 
-    /// This is an alias for `read_element::<Explicit<T, tag>>` for use when
-    /// MSRV is < 1.51.
+    /// This is an alias for `read_element::<Explicit<T, tag>>`
     pub fn read_explicit_element<T: Asn1Readable<'a>>(&mut self, tag: u32) -> ParseResult<T> {
         let expected_tag = crate::explicit_tag(tag);
         let tlv = self.read_tlv()?;
@@ -299,8 +298,7 @@ impl<'a> Parser<'a> {
         parse_single(tlv.data())
     }
 
-    /// This is an alias for `read_element::<Explicit<T, tag, 1>>` for use when
-    /// MSRV is < 1.51.
+    /// This is an alias for `read_element::<Explicit<T, tag, 1>>`
     pub fn read_explicit_application_element<T: Asn1Readable<'a>>(
         &mut self,
         tag: u32,
@@ -315,8 +313,7 @@ impl<'a> Parser<'a> {
         parse_single(tlv.data())
     }
 
-    /// This is an alias for `read_element::<Option<Explicit<T, tag>>>` for use
-    /// when MSRV is <1.51.
+    /// This is an alias for `read_element::<Option<Explicit<T, tag>>>`
     pub fn read_optional_explicit_element<T: Asn1Readable<'a>>(
         &mut self,
         tag: u32,
@@ -329,8 +326,7 @@ impl<'a> Parser<'a> {
         Ok(Some(parse_single::<T>(tlv.data())?))
     }
 
-    /// This is an alias for `read_element::<Option<Explicit<T, tag, 1>>>` for use
-    /// when MSRV is <1.51.
+    /// This is an alias for `read_element::<Option<Explicit<T, tag, 1>>>`
     pub fn read_optional_explicit_application_element<T: Asn1Readable<'a>>(
         &mut self,
         tag: u32,
@@ -343,8 +339,7 @@ impl<'a> Parser<'a> {
         Ok(Some(parse_single::<T>(tlv.data())?))
     }
 
-    /// This is an alias for `read_element::<Implicit<T, tag>>` for use when
-    /// MSRV is <1.51.
+    /// This is an alias for `read_element::<Implicit<T, tag>>`
     pub fn read_implicit_element<T: SimpleAsn1Readable<'a>>(&mut self, tag: u32) -> ParseResult<T> {
         let expected_tag = crate::implicit_tag(tag, T::TAG);
         let tlv = self.read_tlv()?;
@@ -356,8 +351,7 @@ impl<'a> Parser<'a> {
         T::parse_data(tlv.data())
     }
 
-    /// This is an alias for `read_element::<Implicit<T, tag, 1>>` for use when
-    /// MSRV is <1.51.
+    /// This is an alias for `read_element::<Implicit<T, tag, 1>>`
     pub fn read_implicit_application_element<T: SimpleAsn1Readable<'a>>(
         &mut self,
         tag: u32,
@@ -372,8 +366,7 @@ impl<'a> Parser<'a> {
         T::parse_data(tlv.data())
     }
 
-    /// This is an alias for `read_element::<Option<Implicit<T, tag>>>` for use
-    /// when MSRV is <1.51.
+    /// This is an alias for `read_element::<Option<Implicit<T, tag>>>`
     pub fn read_optional_implicit_element<T: SimpleAsn1Readable<'a>>(
         &mut self,
         tag: u32,
@@ -386,8 +379,7 @@ impl<'a> Parser<'a> {
         Ok(Some(T::parse_data(tlv.data())?))
     }
 
-    /// This is an alias for `read_element::<Option<Implicit<T, tag, 1>>>` for use
-    /// when MSRV is <1.51.
+    /// This is an alias for `read_element::<Option<Implicit<T, tag, 1>>>`
     pub fn read_optional_implicit_application_element<T: SimpleAsn1Readable<'a>>(
         &mut self,
         tag: u32,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -362,8 +362,7 @@ impl<'a> Parser<'a> {
         &mut self,
         tag: u32,
     ) -> ParseResult<T> {
-        let expected_tag =
-            crate::implicit_tag_application(tag, T::TAG);
+        let expected_tag = crate::implicit_tag_application(tag, T::TAG);
         let tlv = self.read_tlv()?;
         if tlv.tag != expected_tag {
             return Err(ParseError::new(ParseErrorKind::UnexpectedTag {
@@ -393,8 +392,7 @@ impl<'a> Parser<'a> {
         &mut self,
         tag: u32,
     ) -> ParseResult<Option<T>> {
-        let expected_tag =
-            crate::implicit_tag_application(tag, T::TAG);
+        let expected_tag = crate::implicit_tag_application(tag, T::TAG);
         if self.peek_tag() != Some(expected_tag) {
             return Ok(None);
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,5 @@
 use crate::types::{Asn1Readable, SimpleAsn1Readable, Tlv};
-use crate::{Tag, TagClass};
+use crate::Tag;
 use core::fmt;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -305,7 +305,7 @@ impl<'a> Parser<'a> {
         &mut self,
         tag: u32,
     ) -> ParseResult<T> {
-        let expected_tag = crate::explicit_tag_class::<{ TagClass::Application as u8 }>(tag);
+        let expected_tag = crate::explicit_tag_application(tag);
         let tlv = self.read_tlv()?;
         if tlv.tag != expected_tag {
             return Err(ParseError::new(ParseErrorKind::UnexpectedTag {
@@ -335,7 +335,7 @@ impl<'a> Parser<'a> {
         &mut self,
         tag: u32,
     ) -> ParseResult<Option<T>> {
-        let expected_tag = crate::explicit_tag_class::<{ TagClass::Application as u8 }>(tag);
+        let expected_tag = crate::explicit_tag_application(tag);
         if self.peek_tag() != Some(expected_tag) {
             return Ok(None);
         }
@@ -363,7 +363,7 @@ impl<'a> Parser<'a> {
         tag: u32,
     ) -> ParseResult<T> {
         let expected_tag =
-            crate::implicit_tag_class::<{ TagClass::Application as u8 }>(tag, T::TAG);
+            crate::implicit_tag_application(tag, T::TAG);
         let tlv = self.read_tlv()?;
         if tlv.tag != expected_tag {
             return Err(ParseError::new(ParseErrorKind::UnexpectedTag {
@@ -394,7 +394,7 @@ impl<'a> Parser<'a> {
         tag: u32,
     ) -> ParseResult<Option<T>> {
         let expected_tag =
-            crate::implicit_tag_class::<{ TagClass::Application as u8 }>(tag, T::TAG);
+            crate::implicit_tag_application(tag, T::TAG);
         if self.peek_tag() != Some(expected_tag) {
             return Ok(None);
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1673,13 +1673,13 @@ mod tests {
                 b"\x02\x01\xff",
             ),
         ]);
-        const CONTEXT_SPECIFIC: u8 = TagClass::ContextSpecific as u8;
-        assert_parses::<Implicit<bool, 2, { CONTEXT_SPECIFIC }>>(&[
+        const CONTEXT_SPECIFIC: TagClass = TagClass::ContextSpecific;
+        assert_parses::<Implicit<bool, 2, { CONTEXT_SPECIFIC.as_u8() }>>(&[
             (Ok(Implicit::new(true)), b"\x82\x01\xff"),
             (Ok(Implicit::new(false)), b"\x82\x01\x00"),
         ]);
-        const APPLICATION: u8 = TagClass::Application as u8;
-        assert_parses::<Implicit<bool, 2, { APPLICATION }>>(&[
+        const APPLICATION: TagClass = TagClass::Application;
+        assert_parses::<Implicit<bool, 2, { APPLICATION.as_u8() }>>(&[
             (Ok(Implicit::new(true)), b"\x42\x01\xff"),
             (Ok(Implicit::new(false)), b"\x42\x01\x00"),
             (

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1600,7 +1600,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_implicit() {
+    fn test_parse_implicit_w_const_generics() {
         assert_parses::<Implicit<bool, 2>>(&[
             (Ok(Implicit::new(true)), b"\x82\x01\xff"),
             (Ok(Implicit::new(false)), b"\x82\x01\x00"),
@@ -1634,7 +1634,10 @@ mod tests {
             ),
             (Err(ParseError::new(ParseErrorKind::ShortData)), b""),
         ]);
+    }
 
+    #[test]
+    fn test_parse_implicit_wo_const_generics() {
         assert_parses_cb(
             &[
                 (Ok(Some(true)), b"\x82\x01\xff"),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1600,10 +1600,32 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_implicit_w_const_generics() {
+    fn test_parse_implicit_with_const_generics() {
         assert_parses::<Implicit<bool, 2>>(&[
             (Ok(Implicit::new(true)), b"\x82\x01\xff"),
             (Ok(Implicit::new(false)), b"\x82\x01\x00"),
+            (
+                Err(ParseError::new(ParseErrorKind::UnexpectedTag {
+                    actual: Tag::primitive(0x01),
+                })),
+                b"\x01\x01\xff",
+            ),
+            (
+                Err(ParseError::new(ParseErrorKind::UnexpectedTag {
+                    actual: Tag::primitive(0x02),
+                })),
+                b"\x02\x01\xff",
+            ),
+        ]);
+        const CONTEXT_SPECIFIC: u8 = TagClass::ContextSpecific as u8;
+        assert_parses::<Implicit<bool, 2, { CONTEXT_SPECIFIC }>>(&[
+            (Ok(Implicit::new(true)), b"\x82\x01\xff"),
+            (Ok(Implicit::new(false)), b"\x82\x01\x00"),
+        ]);
+        const APPLICATION: u8 = TagClass::Application as u8;
+        assert_parses::<Implicit<bool, 2, { APPLICATION }>>(&[
+            (Ok(Implicit::new(true)), b"\x42\x01\xff"),
+            (Ok(Implicit::new(false)), b"\x42\x01\x00"),
             (
                 Err(ParseError::new(ParseErrorKind::UnexpectedTag {
                     actual: Tag::primitive(0x01),
@@ -1637,7 +1659,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_implicit_wo_const_generics() {
+    fn test_parse_implicit_without_const_generics() {
         assert_parses_cb(
             &[
                 (Ok(Some(true)), b"\x82\x01\xff"),

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -17,7 +17,7 @@ impl TagClass {
             1 => TagClass::Application,
             2 => TagClass::ContextSpecific,
             3 => TagClass::Private,
-            _ => panic!("No matching tag class bits")
+            _ => panic!("No matching tag class bits"),
         }
     }
 }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -16,7 +16,8 @@ impl TagClass {
             0 => TagClass::Universal,
             1 => TagClass::Application,
             2 => TagClass::ContextSpecific,
-            _ => TagClass::Private,
+            3 => TagClass::Private,
+            _ => panic!("No matching tag class bits")
         }
     }
 }
@@ -43,16 +44,7 @@ impl Tag {
         let constructed = tag & CONSTRUCTED == CONSTRUCTED;
 
         let tag_class_bits = tag >> 6;
-        let class = if tag_class_bits == TagClass::Universal as u8 {
-            TagClass::Universal
-        } else if tag_class_bits == TagClass::Application as u8 {
-            TagClass::Application
-        } else if tag_class_bits == TagClass::ContextSpecific as u8 {
-            TagClass::ContextSpecific
-        } else {
-            assert!(tag_class_bits == TagClass::Private as u8);
-            TagClass::Private
-        };
+        let class = TagClass::from_u8(tag_class_bits);
 
         // Long form tag
         if value == 0x1f {
@@ -139,13 +131,35 @@ mod tests {
     use super::{Tag, TagClass, CONSTRUCTED};
 
     #[test]
-    fn test_class_from_u8() {
+    fn test_tagclass_from_u8() {
         assert_eq!(TagClass::from_u8(0), TagClass::Universal);
         assert_eq!(TagClass::from_u8(1), TagClass::Application);
         assert_eq!(TagClass::from_u8(2), TagClass::ContextSpecific);
-        for i in 3..7 {
-            assert_eq!(TagClass::from_u8(i), TagClass::Private);
-        }
+        assert_eq!(TagClass::from_u8(3), TagClass::Private);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_tagclass_from_u8_given_4_should_panic() {
+        TagClass::from_u8(4);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_tagclass_from_u8_given_5_should_panic() {
+        TagClass::from_u8(5);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_tagclass_from_u8_given_6_should_panic() {
+        TagClass::from_u8(6);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_tagclass_from_u8_given_7_should_panic() {
+        TagClass::from_u8(7);
     }
 
     #[test]

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -4,14 +4,14 @@ use crate::writer::{WriteBuf, WriteResult};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum TagClass {
-    Universal = 0b00,
-    Application = 0b01,
-    ContextSpecific = 0b10,
-    Private = 0b11,
+    Universal,
+    Application,
+    ContextSpecific,
+    Private,
 }
 
 impl TagClass {
-    pub(crate) const fn from_u8(value: u8) -> TagClass {
+    pub(crate) const fn from_u8(value: u8) -> Self {
         match value {
             0 => TagClass::Universal,
             1 => TagClass::Application,

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -20,6 +20,15 @@ impl TagClass {
             _ => panic!("No matching tag class bits"),
         }
     }
+
+    pub const fn as_u8(&self) -> u8 {
+        match self {
+            TagClass::Universal => 0,
+            TagClass::Application => 1,
+            TagClass::ContextSpecific => 2,
+            TagClass::Private => 3,
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -3,11 +3,22 @@ use crate::parser::{ParseError, ParseErrorKind, ParseResult};
 use crate::writer::{WriteBuf, WriteResult};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub(crate) enum TagClass {
+pub enum TagClass {
     Universal = 0b00,
     Application = 0b01,
     ContextSpecific = 0b10,
     Private = 0b11,
+}
+
+impl TagClass {
+    pub(crate) const fn from_u8(value: u8) -> TagClass {
+        match value {
+            0 => TagClass::Universal,
+            1 => TagClass::Application,
+            2 => TagClass::ContextSpecific,
+            _ => TagClass::Private,
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -126,6 +137,16 @@ impl Tag {
 #[cfg(test)]
 mod tests {
     use super::{Tag, TagClass, CONSTRUCTED};
+
+    #[test]
+    fn test_class_from_u8() {
+        assert_eq!(TagClass::from_u8(0), TagClass::Universal);
+        assert_eq!(TagClass::from_u8(1), TagClass::Application);
+        assert_eq!(TagClass::from_u8(2), TagClass::ContextSpecific);
+        for i in 3..7 {
+            assert_eq!(TagClass::from_u8(i), TagClass::Private);
+        }
+    }
 
     #[test]
     fn test_constructed() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,11 +9,8 @@ use core::mem;
 use crate::writer::Writer;
 use crate::{
     parse, parse_single, BitString, ObjectIdentifier, OwnedBitString, ParseError, ParseErrorKind,
-    ParseLocation, ParseResult, Parser, Tag, WriteBuf, WriteResult,
+    ParseLocation, ParseResult, Parser, Tag, TagClass, WriteBuf, WriteResult,
 };
-
-#[cfg(feature = "const-generics")]
-use crate::TagClass;
 
 /// Any type that can be parsed as DER ASN.1.
 pub trait Asn1Readable<'a>: Sized {

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,8 +9,11 @@ use core::mem;
 use crate::writer::Writer;
 use crate::{
     parse, parse_single, BitString, ObjectIdentifier, OwnedBitString, ParseError, ParseErrorKind,
-    ParseLocation, ParseResult, Parser, Tag, TagClass, WriteBuf, WriteResult,
+    ParseLocation, ParseResult, Parser, Tag, WriteBuf, WriteResult,
 };
+
+#[cfg(feature = "const-generics")]
+use crate::TagClass;
 
 /// Any type that can be parsed as DER ASN.1.
 pub trait Asn1Readable<'a>: Sized {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1505,12 +1505,17 @@ impl<'a, T: SimpleAsn1Writable, const TAG: u32, const TAG_CLASS: u8> SimpleAsn1W
 /// `Explicit` is a type which wraps another ASN.1 type, indicating that the tag is an ASN.1
 /// `EXPLICIT`. This will generally be used with `Option` or `Choice`.
 #[derive(PartialEq, Eq, Debug)]
-pub struct Explicit<'a, T, const TAG: u32> {
+pub struct Explicit<
+    'a,
+    T,
+    const TAG: u32,
+    const TAG_CLASS: u8 = { TagClass::ContextSpecific as u8 },
+> {
     inner: T,
     _lifetime: PhantomData<&'a ()>,
 }
 
-impl<'a, T, const TAG: u32> Explicit<'a, T, { TAG }> {
+impl<'a, T, const TAG: u32, const TAG_CLASS: u8> Explicit<'a, T, { TAG }, { TAG_CLASS }> {
     pub fn new(v: T) -> Self {
         Explicit {
             inner: v,
@@ -1523,21 +1528,27 @@ impl<'a, T, const TAG: u32> Explicit<'a, T, { TAG }> {
     }
 }
 
-impl<'a, T, const TAG: u32> From<T> for Explicit<'a, T, { TAG }> {
+impl<'a, T, const TAG: u32, const TAG_CLASS: u8> From<T>
+    for Explicit<'a, T, { TAG }, { TAG_CLASS }>
+{
     fn from(v: T) -> Self {
         Explicit::new(v)
     }
 }
 
-impl<'a, T: Asn1Readable<'a>, const TAG: u32> SimpleAsn1Readable<'a> for Explicit<'a, T, { TAG }> {
-    const TAG: Tag = crate::explicit_tag(TAG);
+impl<'a, T: Asn1Readable<'a>, const TAG: u32, const TAG_CLASS: u8> SimpleAsn1Readable<'a>
+    for Explicit<'a, T, { TAG }, { TAG_CLASS }>
+{
+    const TAG: Tag = crate::explicit_tag_class::<TAG_CLASS>(TAG);
     fn parse_data(data: &'a [u8]) -> ParseResult<Self> {
         Ok(Explicit::new(parse(data, Parser::read_element::<T>)?))
     }
 }
 
-impl<'a, T: Asn1Writable, const TAG: u32> SimpleAsn1Writable for Explicit<'a, T, { TAG }> {
-    const TAG: Tag = crate::explicit_tag(TAG);
+impl<'a, T: Asn1Writable, const TAG: u32, const TAG_CLASS: u8> SimpleAsn1Writable
+    for Explicit<'a, T, { TAG }, { TAG_CLASS }>
+{
+    const TAG: Tag = crate::explicit_tag_class::<TAG_CLASS>(TAG);
     fn write_data(&self, dest: &mut WriteBuf) -> WriteResult {
         Writer::new(dest).write_element(&self.inner)
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1487,7 +1487,7 @@ impl<'a, T, const TAG: u32, const TAG_CLASS: u8> From<T>
 impl<'a, T: SimpleAsn1Readable<'a>, const TAG: u32, const TAG_CLASS: u8> SimpleAsn1Readable<'a>
     for Implicit<'a, T, { TAG }, { TAG_CLASS }>
 {
-    const TAG: Tag = crate::implicit_tag_class::<TAG_CLASS>(TAG, T::TAG);
+    const TAG: Tag = crate::implicit_tag_class(TAG, TagClass::from_u8(TAG_CLASS), T::TAG);
     fn parse_data(data: &'a [u8]) -> ParseResult<Self> {
         Ok(Implicit::new(T::parse_data(data)?))
     }
@@ -1496,7 +1496,7 @@ impl<'a, T: SimpleAsn1Readable<'a>, const TAG: u32, const TAG_CLASS: u8> SimpleA
 impl<'a, T: SimpleAsn1Writable, const TAG: u32, const TAG_CLASS: u8> SimpleAsn1Writable
     for Implicit<'a, T, { TAG }, { TAG_CLASS }>
 {
-    const TAG: Tag = crate::implicit_tag_class::<TAG_CLASS>(TAG, T::TAG);
+    const TAG: Tag = crate::implicit_tag_class(TAG, TagClass::from_u8(TAG_CLASS), T::TAG);
     fn write_data(&self, dest: &mut WriteBuf) -> WriteResult {
         self.inner.write_data(dest)
     }
@@ -1539,7 +1539,7 @@ impl<'a, T, const TAG: u32, const TAG_CLASS: u8> From<T>
 impl<'a, T: Asn1Readable<'a>, const TAG: u32, const TAG_CLASS: u8> SimpleAsn1Readable<'a>
     for Explicit<'a, T, { TAG }, { TAG_CLASS }>
 {
-    const TAG: Tag = crate::explicit_tag_class::<TAG_CLASS>(TAG);
+    const TAG: Tag = crate::explicit_tag_class(TAG, TagClass::from_u8(TAG_CLASS));
     fn parse_data(data: &'a [u8]) -> ParseResult<Self> {
         Ok(Explicit::new(parse(data, Parser::read_element::<T>)?))
     }
@@ -1548,7 +1548,7 @@ impl<'a, T: Asn1Readable<'a>, const TAG: u32, const TAG_CLASS: u8> SimpleAsn1Rea
 impl<'a, T: Asn1Writable, const TAG: u32, const TAG_CLASS: u8> SimpleAsn1Writable
     for Explicit<'a, T, { TAG }, { TAG_CLASS }>
 {
-    const TAG: Tag = crate::explicit_tag_class::<TAG_CLASS>(TAG);
+    const TAG: Tag = crate::explicit_tag_class(TAG, TagClass::from_u8(TAG_CLASS));
     fn write_data(&self, dest: &mut WriteBuf) -> WriteResult {
         Writer::new(dest).write_element(&self.inner)
     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -118,7 +118,7 @@ impl Writer<'_> {
         self.write_tlv(tag, |dest| Writer::new(dest).write_element(val))
     }
 
-    /// This is an alias for `write_element::<Explicit<T, tag, 1>>`
+    /// This is an alias for `write_element::<Explicit<T, tag, tag_class>>`
     pub fn write_explicit_class_element<T: Asn1Writable>(
         &mut self,
         val: &T,
@@ -143,7 +143,7 @@ impl Writer<'_> {
         }
     }
 
-    /// This is an alias for `write_element::<Option<Explicit<T, tag, 1>>>`
+    /// This is an alias for `write_element::<Option<Explicit<T, tag, tag_class>>>`
     pub fn write_optional_explicit_class_element<T: Asn1Writable>(
         &mut self,
         val: &Option<T>,
@@ -193,7 +193,7 @@ impl Writer<'_> {
         }
     }
 
-    /// This is an alias for `write_element::<Option<Implicit<T, tag, 1>>>`
+    /// This is an alias for `write_element::<Option<Implicit<T, tag, tag_class>>>`
     pub fn write_optional_implicit_class_element<T: SimpleAsn1Writable>(
         &mut self,
         val: &Option<T>,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -672,18 +672,18 @@ mod tests {
             (Implicit::new(false), b"\x82\x01\x00"),
         ]);
 
-        const CONTEXT_SPECIFIC: u8 = TagClass::ContextSpecific as u8;
-        assert_writes::<Implicit<bool, 2, CONTEXT_SPECIFIC>>(&[
+        const CONTEXT_SPECIFIC: TagClass = TagClass::ContextSpecific;
+        assert_writes::<Implicit<bool, 2, { CONTEXT_SPECIFIC.as_u8() }>>(&[
             (Implicit::new(true), b"\x82\x01\xff"),
             (Implicit::new(false), b"\x82\x01\x00"),
         ]);
-        assert_writes::<Implicit<i32, 2, CONTEXT_SPECIFIC>>(&[
+        assert_writes::<Implicit<i32, 2, { CONTEXT_SPECIFIC.as_u8() }>>(&[
             (Implicit::new(3i32), b"\x82\x01\x03"),
             (Implicit::new(15i32), b"\x82\x01\x0f"),
         ]);
 
-        const APPLICATION: u8 = TagClass::Application as u8;
-        assert_writes::<Implicit<i32, 2, APPLICATION>>(&[
+        const APPLICATION: TagClass = TagClass::Application;
+        assert_writes::<Implicit<i32, 2, { APPLICATION.as_u8() }>>(&[
             (Implicit::new(3i32), b"\x42\x01\x03"),
             (Implicit::new(15i32), b"\x42\x01\x0f"),
         ]);
@@ -775,14 +775,14 @@ mod tests {
             (Explicit::new(false), b"\xa2\x03\x01\x01\x00"),
         ]);
 
-        const CONTEXT_SPECIFIC: u8 = TagClass::ContextSpecific as u8;
-        assert_writes::<Explicit<bool, 2, CONTEXT_SPECIFIC>>(&[
+        const CONTEXT_SPECIFIC: TagClass = TagClass::ContextSpecific;
+        assert_writes::<Explicit<bool, 2, { CONTEXT_SPECIFIC.as_u8() }>>(&[
             (Explicit::new(true), b"\xa2\x03\x01\x01\xff"),
             (Explicit::new(false), b"\xa2\x03\x01\x01\x00"),
         ]);
 
-        const APPLICATION: u8 = TagClass::Application as u8;
-        assert_writes::<Explicit<bool, 2, APPLICATION>>(&[
+        const APPLICATION: TagClass = TagClass::Application;
+        assert_writes::<Explicit<bool, 2, { APPLICATION.as_u8() }>>(&[
             (Explicit::new(true), b"\x62\x03\x01\x01\xff"),
             (Explicit::new(false), b"\x62\x03\x01\x01\x00"),
         ]);

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -112,15 +112,13 @@ impl Writer<'_> {
         val.write(self)
     }
 
-    /// This is an alias for `write_element::<Explicit<T, tag>>` for use when
-    /// MSRV is <1.51.
+    /// This is an alias for `write_element::<Explicit<T, tag>>`
     pub fn write_explicit_element<T: Asn1Writable>(&mut self, val: &T, tag: u32) -> WriteResult {
         let tag = crate::explicit_tag(tag);
         self.write_tlv(tag, |dest| Writer::new(dest).write_element(val))
     }
 
-    /// This is an alias for `write_element::<Explicit<T, tag, 1>>` for use when
-    /// MSRV is <1.51.
+    /// This is an alias for `write_element::<Explicit<T, tag, 1>>`
     pub fn write_explicit_application_element<T: Asn1Writable>(
         &mut self,
         val: &T,
@@ -130,8 +128,7 @@ impl Writer<'_> {
         self.write_tlv(tag, |dest| Writer::new(dest).write_element(val))
     }
 
-    /// This is an alias for `write_element::<Option<Explicit<T, tag>>>` for
-    /// use when MSRV is <1.51.
+    /// This is an alias for `write_element::<Option<Explicit<T, tag>>>`
     pub fn write_optional_explicit_element<T: Asn1Writable>(
         &mut self,
         val: &Option<T>,
@@ -145,8 +142,7 @@ impl Writer<'_> {
         }
     }
 
-    /// This is an alias for `write_element::<Option<Explicit<T, tag, 1>>>` for
-    /// use when MSRV is <1.51.
+    /// This is an alias for `write_element::<Option<Explicit<T, tag, 1>>>`
     pub fn write_optional_explicit_application_element<T: Asn1Writable>(
         &mut self,
         val: &Option<T>,
@@ -160,8 +156,7 @@ impl Writer<'_> {
         }
     }
 
-    /// This is an alias for `write_element::<Implicit<T, tag>>` for use when
-    /// MSRV is <1.51.
+    /// This is an alias for `write_element::<Implicit<T, tag>>`
     pub fn write_implicit_element<T: SimpleAsn1Writable>(
         &mut self,
         val: &T,
@@ -171,8 +166,7 @@ impl Writer<'_> {
         self.write_tlv(tag, |dest| val.write_data(dest))
     }
 
-    /// This is an alias for `write_element::<Implicit<T, tag, tag_class>>` for use when
-    /// MSRV is <1.51.
+    /// This is an alias for `write_element::<Implicit<T, tag, tag_class>>`
     pub fn write_implicit_application_element<T: SimpleAsn1Writable>(
         &mut self,
         val: &T,
@@ -182,8 +176,7 @@ impl Writer<'_> {
         self.write_tlv(tag, |dest| val.write_data(dest))
     }
 
-    /// This is an alias for `write_element::<Implicit<T, tag, tag_class>>` for use when
-    /// MSRV is <1.51.
+    /// This is an alias for `write_element::<Implicit<T, tag, tag_class>>`
     pub fn write_implicit_context_specific_element<T: SimpleAsn1Writable>(
         &mut self,
         val: &T,
@@ -193,8 +186,7 @@ impl Writer<'_> {
         self.write_tlv(tag, |dest| val.write_data(dest))
     }
 
-    /// This is an alias for `write_element::<Option<Implicit<T, tag>>>` for
-    /// use when MSRV is <1.51.
+    /// This is an alias for `write_element::<Option<Implicit<T, tag>>>`
     pub fn write_optional_implicit_element<T: SimpleAsn1Writable>(
         &mut self,
         val: &Option<T>,
@@ -208,8 +200,7 @@ impl Writer<'_> {
         }
     }
 
-    /// This is an alias for `write_element::<Option<Implicit<T, tag, 1>>>` for
-    /// use when MSRV is <1.51.
+    /// This is an alias for `write_element::<Option<Implicit<T, tag, 1>>>`
     pub fn write_optional_implicit_application_element<T: SimpleAsn1Writable>(
         &mut self,
         val: &Option<T>,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,5 +1,5 @@
 use crate::types::{Asn1Writable, SimpleAsn1Writable};
-use crate::{Tag, TagClass};
+use crate::Tag;
 use alloc::vec::Vec;
 use alloc::{fmt, vec};
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -121,7 +121,7 @@ impl Writer<'_> {
 
     /// This is an alias for `write_element::<Explicit<T, tag, 1>>` for use when
     /// MSRV is <1.51.
-    pub fn write_explicit_element_application<T: Asn1Writable>(
+    pub fn write_explicit_application_element<T: Asn1Writable>(
         &mut self,
         val: &T,
         tag: u32,
@@ -147,7 +147,7 @@ impl Writer<'_> {
 
     /// This is an alias for `write_element::<Option<Explicit<T, tag, 1>>>` for
     /// use when MSRV is <1.51.
-    pub fn write_optional_explicit_element_application<T: Asn1Writable>(
+    pub fn write_optional_explicit_application_element<T: Asn1Writable>(
         &mut self,
         val: &Option<T>,
         tag: u32,
@@ -705,13 +705,26 @@ mod tests {
     }
 
     #[test]
-    fn test_write_implicit_without_const_generics() {
+    fn test_write_without_const_generics() {
         assert_eq!(
             write(|w| { w.write_optional_implicit_element(&Some(true), 2) }).unwrap(),
             b"\x82\x01\xff"
         );
         assert_eq!(
+            write(|w| { w.write_optional_implicit_application_element(&Some(true), 2) }).unwrap(),
+            b"\x42\x01\xff"
+        );
+        assert_eq!(
+            write(|w| { w.write_optional_implicit_application_element::<u8>(&None, 2) }).unwrap(),
+            b""
+        );
+
+        assert_eq!(
             write(|w| { w.write_optional_explicit_element::<u8>(&None, 2) }).unwrap(),
+            b""
+        );
+        assert_eq!(
+            write(|w| { w.write_optional_explicit_application_element::<u8>(&None, 2) }).unwrap(),
             b""
         );
 
@@ -725,6 +738,16 @@ mod tests {
         assert_eq!(
             write(|w| { w.write_optional_explicit_element::<SequenceWriter>(&None, 2) }).unwrap(),
             b""
+        );
+        assert_eq!(
+            write(|w| {
+                w.write_optional_explicit_application_element(
+                    &Some(SequenceWriter::new(&|_w| Ok(()))),
+                    2,
+                )
+            })
+            .unwrap(),
+            b"\x62\x02\x30\0"
         );
 
         assert_eq!(

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -709,12 +709,27 @@ mod tests {
     }
 
     #[test]
-    fn test_write_explicit() {
+    fn test_write_explicit_with_const_generics() {
         assert_writes::<Explicit<bool, 2>>(&[
             (Explicit::new(true), b"\xa2\x03\x01\x01\xff"),
             (Explicit::new(false), b"\xa2\x03\x01\x01\x00"),
         ]);
 
+        const CONTEXT_SPECIFIC: u8 = TagClass::ContextSpecific as u8;
+        assert_writes::<Explicit<bool, 2, CONTEXT_SPECIFIC>>(&[
+            (Explicit::new(true), b"\xa2\x03\x01\x01\xff"),
+            (Explicit::new(false), b"\xa2\x03\x01\x01\x00"),
+        ]);
+
+        const APPLICATION: u8 = TagClass::Application as u8;
+        assert_writes::<Explicit<bool, 2, APPLICATION>>(&[
+            (Explicit::new(true), b"\x62\x03\x01\x01\xff"),
+            (Explicit::new(false), b"\x62\x03\x01\x01\x00"),
+        ]);
+    }
+
+    #[test]
+    fn test_write_explicit_without_const_generics() {
         assert_eq!(
             write(|w| { w.write_optional_explicit_element(&Some(true), 2) }).unwrap(),
             b"\xa2\x03\x01\x01\xff"

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -288,8 +288,8 @@ mod tests {
         parse_single, BMPString, BigInt, BigUint, BitString, Choice1, Choice2, Choice3, DateTime,
         Enumerated, Explicit, GeneralizedTime, IA5String, Implicit, ObjectIdentifier,
         OctetStringEncoded, OwnedBitString, PrintableString, Sequence, SequenceOf,
-        SequenceOfWriter, SequenceWriter, SetOf, SetOfWriter, Tlv, UniversalString, UtcTime,
-        Utf8String, VisibleString, WriteError,
+        SequenceOfWriter, SequenceWriter, SetOf, SetOfWriter, TagClass, Tlv, UniversalString,
+        UtcTime, Utf8String, VisibleString, WriteError,
     };
     use alloc::vec::Vec;
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -182,6 +182,21 @@ impl Writer<'_> {
         }
     }
 
+    /// This is an alias for `write_element::<Option<Implicit<T, tag, 1>>>` for
+    /// use when MSRV is <1.51.
+    pub fn write_optional_implicit_application_element<T: SimpleAsn1Writable>(
+        &mut self,
+        val: &Option<T>,
+        tag: u32,
+    ) -> WriteResult {
+        if let Some(v) = val {
+            let tag = crate::implicit_tag_class::<{ TagClass::Application as u8 }>(tag, T::TAG);
+            self.write_tlv(tag, |dest| v.write_data(dest))
+        } else {
+            Ok(())
+        }
+    }
+
     /// Writes a TLV with the specified tag where the value is any bytes
     /// written to the `Vec` in the callback. The length portion of the
     /// TLV is automatically computed.

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -119,6 +119,17 @@ impl Writer<'_> {
         self.write_tlv(tag, |dest| Writer::new(dest).write_element(val))
     }
 
+    /// This is an alias for `write_element::<Explicit<T, tag, 1>>` for use when
+    /// MSRV is <1.51.
+    pub fn write_explicit_element_application<T: Asn1Writable>(
+        &mut self,
+        val: &T,
+        tag: u32,
+    ) -> WriteResult {
+        let tag = crate::explicit_tag_class::<{ TagClass::Application as u8 }>(tag);
+        self.write_tlv(tag, |dest| Writer::new(dest).write_element(val))
+    }
+
     /// This is an alias for `write_element::<Option<Explicit<T, tag>>>` for
     /// use when MSRV is <1.51.
     pub fn write_optional_explicit_element<T: Asn1Writable>(
@@ -128,6 +139,21 @@ impl Writer<'_> {
     ) -> WriteResult {
         if let Some(v) = val {
             let tag = crate::explicit_tag(tag);
+            self.write_tlv(tag, |dest| Writer::new(dest).write_element(v))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// This is an alias for `write_element::<Option<Explicit<T, tag, 1>>>` for
+    /// use when MSRV is <1.51.
+    pub fn write_optional_explicit_element_application<T: Asn1Writable>(
+        &mut self,
+        val: &Option<T>,
+        tag: u32,
+    ) -> WriteResult {
+        if let Some(v) = val {
+            let tag = crate::explicit_tag_class::<{ TagClass::Application as u8 }>(tag);
             self.write_tlv(tag, |dest| Writer::new(dest).write_element(v))
         } else {
             Ok(())

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -126,7 +126,7 @@ impl Writer<'_> {
         val: &T,
         tag: u32,
     ) -> WriteResult {
-        let tag = crate::explicit_tag_class::<{ TagClass::Application as u8 }>(tag);
+        let tag = crate::explicit_tag_application(tag);
         self.write_tlv(tag, |dest| Writer::new(dest).write_element(val))
     }
 
@@ -153,7 +153,7 @@ impl Writer<'_> {
         tag: u32,
     ) -> WriteResult {
         if let Some(v) = val {
-            let tag = crate::explicit_tag_class::<{ TagClass::Application as u8 }>(tag);
+            let tag = crate::explicit_tag_application(tag);
             self.write_tlv(tag, |dest| Writer::new(dest).write_element(v))
         } else {
             Ok(())
@@ -178,7 +178,7 @@ impl Writer<'_> {
         val: &T,
         tag: u32,
     ) -> WriteResult {
-        let tag = crate::implicit_tag_class::<{ TagClass::Application as u8 }>(tag, T::TAG);
+        let tag = crate::implicit_tag_application(tag, T::TAG);
         self.write_tlv(tag, |dest| val.write_data(dest))
     }
 
@@ -189,7 +189,7 @@ impl Writer<'_> {
         val: &T,
         tag: u32,
     ) -> WriteResult {
-        let tag = crate::implicit_tag_class::<{ TagClass::ContextSpecific as u8 }>(tag, T::TAG);
+        let tag = crate::implicit_tag_context_specific(tag, T::TAG);
         self.write_tlv(tag, |dest| val.write_data(dest))
     }
 
@@ -216,7 +216,7 @@ impl Writer<'_> {
         tag: u32,
     ) -> WriteResult {
         if let Some(v) = val {
-            let tag = crate::implicit_tag_class::<{ TagClass::Application as u8 }>(tag, T::TAG);
+            let tag = crate::implicit_tag_application(tag, T::TAG);
             self.write_tlv(tag, |dest| v.write_data(dest))
         } else {
             Ok(())

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -640,12 +640,31 @@ mod tests {
     }
 
     #[test]
-    fn test_write_implicit() {
+    fn test_write_implicit_with_const_generics() {
         assert_writes::<Implicit<bool, 2>>(&[
             (Implicit::new(true), b"\x82\x01\xff"),
             (Implicit::new(false), b"\x82\x01\x00"),
         ]);
 
+        const CONTEXT_SPECIFIC: u8 = TagClass::ContextSpecific as u8;
+        assert_writes::<Implicit<bool, 2, CONTEXT_SPECIFIC>>(&[
+            (Implicit::new(true), b"\x82\x01\xff"),
+            (Implicit::new(false), b"\x82\x01\x00"),
+        ]);
+        assert_writes::<Implicit<i32, 2, CONTEXT_SPECIFIC>>(&[
+            (Implicit::new(3i32), b"\x82\x01\x03"),
+            (Implicit::new(15i32), b"\x82\x01\x0f"),
+        ]);
+
+        const APPLICATION: u8 = TagClass::Application as u8;
+        assert_writes::<Implicit<i32, 2, APPLICATION>>(&[
+            (Implicit::new(3i32), b"\x42\x01\x03"),
+            (Implicit::new(15i32), b"\x42\x01\x0f"),
+        ]);
+    }
+
+    #[test]
+    fn test_write_implicit_without_const_generics() {
         assert_eq!(
             write(|w| { w.write_optional_implicit_element(&Some(true), 2) }).unwrap(),
             b"\x82\x01\xff"

--- a/tests/const_generic_tests.rs
+++ b/tests/const_generic_tests.rs
@@ -1,10 +1,8 @@
-#[cfg(feature = "const-generics")]
 use asn1::{
     explicit_tag, explicit_tag_application, explicit_tag_class, implicit_tag,
     implicit_tag_application, implicit_tag_class, TagClass,
 };
 
-#[cfg(feature = "const-generics")]
 #[test]
 fn const_generic_shall_behave_the_same() {
     let inner_tag = explicit_tag(21);

--- a/tests/const_generic_tests.rs
+++ b/tests/const_generic_tests.rs
@@ -1,28 +1,15 @@
-use asn1::{
-    explicit_tag, explicit_tag_application, explicit_tag_class, implicit_tag,
-    implicit_tag_application, implicit_tag_class, TagClass,
-};
+use asn1::{explicit_tag, explicit_tag_class, implicit_tag, implicit_tag_class, TagClass};
 
 #[test]
 fn const_generic_shall_behave_the_same() {
     let inner_tag = explicit_tag(21);
-    const CONTEXT_SPECIFIC_TAG: u8 = TagClass::ContextSpecific as u8;
-    const APPLICATION_TAG: u8 = TagClass::Application as u8;
 
     assert_eq!(
         implicit_tag(0, inner_tag),
-        implicit_tag_class::<CONTEXT_SPECIFIC_TAG>(0, inner_tag)
-    );
-    assert_eq!(
-        implicit_tag_application(0, inner_tag),
-        implicit_tag_class::<APPLICATION_TAG>(0, inner_tag)
+        implicit_tag_class(0, TagClass::ContextSpecific, inner_tag)
     );
     assert_eq!(
         explicit_tag(11),
-        explicit_tag_class::<CONTEXT_SPECIFIC_TAG>(11)
+        explicit_tag_class(11, TagClass::ContextSpecific)
     );
-    assert_eq!(
-        explicit_tag_application(11),
-        explicit_tag_class::<APPLICATION_TAG>(11)
-    )
 }

--- a/tests/const_generic_tests.rs
+++ b/tests/const_generic_tests.rs
@@ -1,0 +1,30 @@
+#[cfg(feature = "const-generics")]
+use asn1::{
+    explicit_tag, explicit_tag_application, explicit_tag_class, implicit_tag,
+    implicit_tag_application, implicit_tag_class, TagClass,
+};
+
+#[cfg(feature = "const-generics")]
+#[test]
+fn const_generic_shall_behave_the_same() {
+    let inner_tag = explicit_tag(21);
+    const CONTEXT_SPECIFIC_TAG: u8 = TagClass::ContextSpecific as u8;
+    const APPLICATION_TAG: u8 = TagClass::Application as u8;
+
+    assert_eq!(
+        implicit_tag(0, inner_tag),
+        implicit_tag_class::<CONTEXT_SPECIFIC_TAG>(0, inner_tag)
+    );
+    assert_eq!(
+        implicit_tag_application(0, inner_tag),
+        implicit_tag_class::<APPLICATION_TAG>(0, inner_tag)
+    );
+    assert_eq!(
+        explicit_tag(11),
+        explicit_tag_class::<CONTEXT_SPECIFIC_TAG>(11)
+    );
+    assert_eq!(
+        explicit_tag_application(11),
+        explicit_tag_class::<APPLICATION_TAG>(11)
+    )
+}

--- a/tests/derive_test.rs
+++ b/tests/derive_test.rs
@@ -484,9 +484,9 @@ fn test_implicit_struct_with_const_generics() {
     };
 
     const TAG_NUMBER: u32 = 0u32;
-    const TAG_CLASS: u8 = TagClass::Application as u8;
+    const TAG_CLASS: TagClass = TagClass::Application;
     let implicit_application_sequence =
-        Implicit::<InitiateSession, TAG_NUMBER, TAG_CLASS>::new(session);
+        Implicit::<InitiateSession, TAG_NUMBER, { TAG_CLASS.as_u8() }>::new(session);
     let expected_bytes: Vec<u8> = vec![
         0x60, 0x27, // session itself
         0x4a, 0x08, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // a

--- a/tests/derive_test.rs
+++ b/tests/derive_test.rs
@@ -557,6 +557,34 @@ fn test_required_explicit() {
 }
 
 #[test]
+fn test_required_explicit_application() {
+    #[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Debug, Eq)]
+    struct RequiredExplicit {
+        #[explicit(0, 1, required)]
+        value: u8,
+    }
+
+    assert_roundtrips::<RequiredExplicit>(&[
+        (
+            Ok(RequiredExplicit { value: 8 }),
+            b"\x30\x05\x60\x03\x02\x01\x08",
+        ),
+        (
+            Err(asn1::ParseError::new(asn1::ParseErrorKind::ShortData)
+                .add_location(asn1::ParseLocation::Field("RequiredExplicit::value"))),
+            b"\x30\x00",
+        ),
+        (
+            Err(asn1::ParseError::new(asn1::ParseErrorKind::UnexpectedTag {
+                actual: asn1::Tag::primitive(11),
+            })
+            .add_location(asn1::ParseLocation::Field("RequiredExplicit::value"))),
+            b"\x30\x03\x0b\x01\x00",
+        ),
+    ]);
+}
+
+#[test]
 fn test_defined_by() {
     const OID1: asn1::ObjectIdentifier = asn1::oid!(1, 2, 3);
     const OID2: asn1::ObjectIdentifier = asn1::oid!(1, 2, 5);

--- a/tests/derive_test.rs
+++ b/tests/derive_test.rs
@@ -455,7 +455,6 @@ fn test_required_implicit() {
     ]);
 }
 
-#[cfg(feature = "const-generics")]
 #[test]
 fn test_implicit_struct_with_const_generics() {
     use asn1::Implicit;

--- a/tests/derive_test.rs
+++ b/tests/derive_test.rs
@@ -485,7 +485,7 @@ fn test_implicit_struct() {
     const TAG_CLASS: u8 = TagClass::Application as u8;
     let implicit_application_sequence =
         Implicit::<InitiateSession, TAG_NUMBER, TAG_CLASS>::new(session);
-        let expected_bytes: Vec<u8> = vec![
+    let expected_bytes: Vec<u8> = vec![
         0x60, 0x27, // session itself
         0x4a, 0x08, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // a
         0x4b, 0x08, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // b

--- a/tests/derive_test.rs
+++ b/tests/derive_test.rs
@@ -485,10 +485,6 @@ fn test_implicit_struct() {
     const TAG_CLASS: u8 = TagClass::Application as u8;
     let implicit_application_sequence =
         Implicit::<InitiateSession, TAG_NUMBER, TAG_CLASS>::new(session);
-
-    let bytes =
-        asn1::write_single::<Implicit<InitiateSession, 0, 1>>(&implicit_application_sequence)
-            .unwrap();
     let expected_bytes: Vec<u8> = vec![
         0x60, 0x27, // session itself
         0x4a, 0x08, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // a

--- a/tests/derive_test.rs
+++ b/tests/derive_test.rs
@@ -434,7 +434,7 @@ fn test_error_parse_location() {
 fn test_required_implicit() {
     #[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Debug, Eq)]
     struct RequiredImplicit {
-        #[implicit(0, 0, required)]
+        #[implicit(0, required)]
         value: u8,
     }
 
@@ -459,13 +459,13 @@ fn test_required_implicit() {
 fn test_implicit_struct() {
     #[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Debug)]
     struct InitiateSession<'a> {
-        #[implicit(10, 1, required)]
+        #[implicit(10, required, application)]
         a: &'a [u8],
-        #[implicit(11, 1, required)]
+        #[implicit(11, required, application)]
         b: &'a [u8],
-        #[implicit(31, 1)]
+        #[implicit(31, application)]
         c: Option<asn1::Utf8String<'a>>,
-        #[implicit(32, 1)]
+        #[implicit(32, application)]
         d: Option<&'a [u8]>,
     }
 
@@ -485,7 +485,7 @@ fn test_implicit_struct() {
     const TAG_CLASS: u8 = TagClass::Application as u8;
     let implicit_application_sequence =
         Implicit::<InitiateSession, TAG_NUMBER, TAG_CLASS>::new(session);
-    let expected_bytes: Vec<u8> = vec![
+        let expected_bytes: Vec<u8> = vec![
         0x60, 0x27, // session itself
         0x4a, 0x08, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // a
         0x4b, 0x08, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // b
@@ -503,7 +503,7 @@ fn test_implicit_struct() {
 fn test_required_implicit_application() {
     #[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Debug, Eq)]
     struct RequiredImplicit {
-        #[implicit(2, 1, required)]
+        #[implicit(2, required, application)]
         value: u8,
     }
 
@@ -528,7 +528,7 @@ fn test_required_implicit_application() {
 fn test_required_explicit() {
     #[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Debug, Eq)]
     struct RequiredExplicit {
-        #[explicit(0, 0, required)]
+        #[explicit(0, required)]
         value: u8,
     }
 
@@ -556,7 +556,7 @@ fn test_required_explicit() {
 fn test_required_explicit_application() {
     #[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Debug, Eq)]
     struct RequiredExplicit {
-        #[explicit(0, 1, required)]
+        #[explicit(0, required, application)]
         value: u8,
     }
 

--- a/tests/derive_test.rs
+++ b/tests/derive_test.rs
@@ -1,4 +1,4 @@
-use asn1::{Implicit, TagClass, Utf8String};
+use asn1::{TagClass, Utf8String};
 use std::fmt;
 
 fn assert_roundtrips<
@@ -455,8 +455,11 @@ fn test_required_implicit() {
     ]);
 }
 
+#[cfg(feature = "const-generics")]
 #[test]
-fn test_implicit_struct() {
+fn test_implicit_struct_with_const_generics() {
+    use asn1::Implicit;
+
     #[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Debug)]
     struct InitiateSession<'a> {
         #[implicit(10, required, application)]


### PR DESCRIPTION
This PR enables defining a tag class from outside - as it defaulted to an `universal` tag.

If you have `const-generics` feature enabled, you can define your TLV with e.g.:
``` Rust
const TAG_CLASS: u8 = TagClass::Application as u8;
let implicit_application_bool = Implicit::<bool, 2, TAG_CLASS>>::new(true);
```
Enums are not yet support as const parameters, that is why I used u8 as a placeholder for now.

The PR also changed the parsing of the derive macros. Now it is possible to define a tag class like this:
```
#[derive(asn1::Asn1Read, asn1::Asn1Write)]
struct SomeStruct<'a> {
    #[implicit(10, required, application)]
    a: &'a [u8],
}
```

If nothing is provided - it will default to the old behavior, i.e. `universal` tags.

This PR also only implements application tags. If `private` or `context-specific` tags are needed, I would open a new Issue/PR for this.

TL;DR:

- You can define tags from outside - either with derive macros or directly with the lib itself.
- only `application` tags are possible at the moment

Just let me know, if the PR direction is correct or not.