### PR TITLE
object_identifier: typo

### DIFF
--- a/src/object_identifier.rs
+++ b/src/object_identifier.rs
@@ -15,7 +15,7 @@ const MAX_OID_LENGTH: usize = 63;
 /// rust-asn1 stores `ObjectIdentifier`s in a fixed-size buffer, therefore
 /// they are limited to OID values whose DER encoding fits into that buffer.
 /// This buffer is sufficiently large to fit all known publically known OIDs,
-/// so this should not effect most people.
+/// so this should not affect most people.
 #[derive(PartialEq, Eq, Clone, Hash)]
 pub struct ObjectIdentifier {
     // Store the OID as DER encoded.


### PR DESCRIPTION
While I'm lurking around.