### PR TITLE
When reading length bytes, read them all at once

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -239,7 +239,8 @@ impl<'a> Parser<'a> {
                 Ok(length)
             }
             0x82 => {
-                let length = usize::from(self.read_u8()?) << 8 | usize::from(self.read_u8()?);
+                let length_bytes = self.read_bytes(2)?;
+                let length = usize::from(length_bytes[0]) << 8 | usize::from(length_bytes[1]);
                 // Enforce that we're not using long form for values <0x80,
                 // and that the first byte of the length is not zero (i.e.
                 // that we're minimally encoded)
@@ -249,9 +250,10 @@ impl<'a> Parser<'a> {
                 Ok(length)
             }
             0x83 => {
-                let length = usize::from(self.read_u8()?) << 16
-                    | usize::from(self.read_u8()?) << 8
-                    | usize::from(self.read_u8()?);
+                let length_bytes = self.read_bytes(3)?;
+                let length = usize::from(length_bytes[0]) << 16
+                    | usize::from(length_bytes[1]) << 8
+                    | usize::from(length_bytes[2]);
                 // Same thing as the 0x82 case
                 if length < 0x10000 {
                     return Err(ParseError::new(ParseErrorKind::InvalidLength));
@@ -259,10 +261,11 @@ impl<'a> Parser<'a> {
                 Ok(length)
             }
             0x84 => {
-                let length = usize::from(self.read_u8()?) << 24
-                    | usize::from(self.read_u8()?) << 16
-                    | usize::from(self.read_u8()?) << 8
-                    | usize::from(self.read_u8()?);
+                let length_bytes = self.read_bytes(4)?;
+                let length = usize::from(length_bytes[0]) << 24
+                    | usize::from(length_bytes[1]) << 16
+                    | usize::from(length_bytes[2]) << 8
+                    | usize::from(length_bytes[3]);
                 // Same thing as the 0x82 case
                 if length < 0x1000000 {
                     return Err(ParseError::new(ParseErrorKind::InvalidLength));


### PR DESCRIPTION
Calling `read_u8` repeatedly leads to multiple length checks, instead of a single one.