### PR TITLE
types: add const generics for SequenceOf length limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         RUST:
           # MSRV
-          - VERSION: "1.57.0"
+          - VERSION: "1.59.0"
             FLAGS: ""
 
           - VERSION: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "BSD-3-Clause"
 description = "ASN.1 (DER) parser and writer for Rust."
 edition = "2021"
 # This specifies the MSRV
-rust-version = "1.57.0"
+rust-version = "1.59.0"
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add `asn1` to the `[dependencies]` section of your `Cargo.toml`:
 asn1 = "0.16"
 ```
 
-Builds on Rust 1.56.0 and newer.
+Builds on Rust 1.59.0 and newer.
 
 `rust-asn1` is compatible with `#![no_std]` environments:
 

--- a/asn1_derive/Cargo.toml
+++ b/asn1_derive/Cargo.toml
@@ -7,7 +7,7 @@ license = "BSD-3-Clause"
 description = "#[derive] support for asn1"
 edition = "2021"
 # This specifies the MSRV
-rust-version = "1.57.0"
+rust-version = "1.59.0"
 
 [lib]
 proc-macro = true

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,1 @@
-
-large-error-threshold = 136
+large-error-threshold = 137

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,4 @@
+# `ParseError` is larger (136 bytes) than the default clippy limit (128 bytes)
+# for error variants; this allows it to pass while catching any future
+# unintended growth. Note that the limit below is exclusive.
 large-error-threshold = 137

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+
+large-error-threshold = 136

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
+#![allow(clippy::result_large_err)]
 
 //! This crate provides you with the ability to generate and parse ASN.1
 //! encoded data. More precisely, it provides you with the ability to generate

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
-#![allow(clippy::result_large_err)]
 
 //! This crate provides you with the ability to generate and parse ASN.1
 //! encoded data. More precisely, it provides you with the ability to generate

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1666,6 +1666,42 @@ mod tests {
     }
 
     #[test]
+    fn test_sequence_of_constrained_lengths() {
+        // Minimum only.
+        assert_parses_cb(
+            &[
+                (
+                    Ok(vec![1, 2, 3]),
+                    b"\x30\x09\x02\x01\x01\x02\x01\x02\x02\x01\x03",
+                ),
+                (
+                    Err(ParseError::new(ParseErrorKind::InvalidValue)),
+                    b"\x30\x00",
+                ),
+            ],
+            |p| Ok(p.read_element::<SequenceOf<'_, i64, 1>>()?.collect()),
+        );
+
+        // Minimum and maximum.
+        assert_parses_cb(
+            &[
+                (
+                    Err(ParseError::new(ParseErrorKind::InvalidValue)),
+                    b"\x30\x09\x02\x01\x01\x02\x01\x02\x02\x01\x03",
+                ),
+                (
+                    Err(ParseError::new(ParseErrorKind::InvalidValue)),
+                    b"\x30\x00",
+                ),
+            ],
+            |p| {
+                Ok(p.read_element::<SequenceOf<'_, i64, 1, 2>>()?
+                    .collect::<Vec<_>>())
+            },
+        );
+    }
+
+    #[test]
     fn parse_set_of() {
         assert_parses_cb(
             &[

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1693,11 +1693,9 @@ mod tests {
                     Err(ParseError::new(ParseErrorKind::InvalidValue)),
                     b"\x30\x00",
                 ),
+                (Ok(vec![3, 1]), b"\x30\x06\x02\x01\x03\x02\x01\x01"),
             ],
-            |p| {
-                Ok(p.read_element::<SequenceOf<'_, i64, 1, 2>>()?
-                    .collect::<Vec<_>>())
-            },
+            |p| Ok(p.read_element::<SequenceOf<'_, i64, 1, 2>>()?.collect()),
         );
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -134,7 +134,7 @@ impl fmt::Display for ParseError {
             ParseErrorKind::InvalidTag => write!(f, "invalid tag"),
             ParseErrorKind::InvalidLength => write!(f, "invalid length"),
             ParseErrorKind::InvalidSize { actual } => {
-                write!(f, "invalid container size: (got {:?})", actual)
+                write!(f, "invalid container size (got {:?})", actual)
             }
             ParseErrorKind::UnexpectedTag { actual } => {
                 write!(f, "unexpected tag (got {:?})", actual)
@@ -421,6 +421,10 @@ mod tests {
             (
                 ParseError::new(ParseErrorKind::InvalidLength),
                 "ASN.1 parsing error: invalid length"
+            ),
+            (
+                ParseError::new(ParseErrorKind::InvalidSize { actual: 0 }),
+                "ASN.1 parsing error: invalid container size (got 0)",
             ),
             (
                 ParseError::new(ParseErrorKind::IntegerOverflow),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -57,7 +57,7 @@ pub enum ParseLocation {
 #[derive(PartialEq, Eq)]
 pub struct ParseError {
     kind: ParseErrorKind,
-    parse_locations: [Option<ParseLocation>; 4],
+    parse_locations: Box<[Option<ParseLocation>; 4]>,
     parse_depth: u8,
 }
 
@@ -65,7 +65,7 @@ impl ParseError {
     pub fn new(kind: ParseErrorKind) -> ParseError {
         ParseError {
             kind,
-            parse_locations: [None, None, None, None],
+            parse_locations: [None, None, None, None].into(),
             parse_depth: 0,
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -57,7 +57,7 @@ pub enum ParseLocation {
 #[derive(PartialEq, Eq)]
 pub struct ParseError {
     kind: ParseErrorKind,
-    parse_locations: Box<[Option<ParseLocation>; 4]>,
+    parse_locations: [Option<ParseLocation>; 4],
     parse_depth: u8,
 }
 
@@ -65,7 +65,7 @@ impl ParseError {
     pub fn new(kind: ParseErrorKind) -> ParseError {
         ParseError {
             kind,
-            parse_locations: [None, None, None, None].into(),
+            parse_locations: [None, None, None, None],
             parse_depth: 0,
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1292,6 +1292,8 @@ impl<'a, T: Asn1Readable<'a>, const MINIMUM_LEN: usize, const MAXIMUM_LEN: usize
 
         if length < MINIMUM_LEN || length > MAXIMUM_LEN {
             return Err(ParseError::new(ParseErrorKind::InvalidSize {
+                min: MINIMUM_LEN,
+                max: MAXIMUM_LEN,
                 actual: length,
             }));
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1322,7 +1322,9 @@ impl<'a, T: Asn1Readable<'a>, const MINIMUM_LEN: usize, const MAXIMUM_LEN: usize
     }
 }
 
-impl<'a, T: Asn1Readable<'a> + PartialEq> PartialEq for SequenceOf<'a, T> {
+impl<'a, T: Asn1Readable<'a> + PartialEq, const MINIMUM_LEN: usize, const MAXIMUM_LEN: usize>
+    PartialEq for SequenceOf<'a, T, MINIMUM_LEN, MAXIMUM_LEN>
+{
     fn eq(&self, other: &Self) -> bool {
         let mut it1 = self.clone();
         let mut it2 = other.clone();
@@ -1340,9 +1342,14 @@ impl<'a, T: Asn1Readable<'a> + PartialEq> PartialEq for SequenceOf<'a, T> {
     }
 }
 
-impl<'a, T: Asn1Readable<'a> + Eq> Eq for SequenceOf<'a, T> {}
+impl<'a, T: Asn1Readable<'a> + Eq, const MINIMUM_LEN: usize, const MAXIMUM_LEN: usize> Eq
+    for SequenceOf<'a, T, MINIMUM_LEN, MAXIMUM_LEN>
+{
+}
 
-impl<'a, T: Asn1Readable<'a> + Hash> Hash for SequenceOf<'a, T> {
+impl<'a, T: Asn1Readable<'a> + Hash, const MINIMUM_LEN: usize, const MAXIMUM_LEN: usize> Hash
+    for SequenceOf<'a, T, MINIMUM_LEN, MAXIMUM_LEN>
+{
     fn hash<H: Hasher>(&self, state: &mut H) {
         for val in self.clone() {
             val.hash(state);
@@ -1862,25 +1869,6 @@ mod tests {
         assert!(seq1.is_empty());
         assert_eq!(seq2.len(), 3);
         assert!(!seq2.is_empty());
-    }
-
-    #[test]
-    fn test_sequence_of_constrained() {
-        let seq1 =
-            parse_single::<SequenceOf<'_, u64>>(b"\x30\x09\x02\x01\x01\x02\x01\x02\x02\x01\x03");
-        assert!(seq1.is_ok());
-
-        // Parse fails because minimum length is 4 but sequence contains 3 items.
-        let seq2 =
-            parse_single::<SequenceOf<'_, u64, 4>>(b"\x30\x09\x02\x01\x01\x02\x01\x02\x02\x01\x03");
-        assert!(seq2.is_err());
-
-        // Parse fails because maximum length is 2 but sequence contains 3 items.
-        // Parse fails because minimum length is 4 but sequence contains 3 items.
-        let seq3 = parse_single::<SequenceOf<'_, u64, 0, 2>>(
-            b"\x30\x09\x02\x01\x01\x02\x01\x02\x02\x01\x03",
-        );
-        assert!(seq3.is_err());
     }
 
     #[cfg(feature = "std")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1291,7 +1291,9 @@ impl<'a, T: Asn1Readable<'a>, const MINIMUM_LEN: usize, const MAXIMUM_LEN: usize
         })?;
 
         if length < MINIMUM_LEN || length > MAXIMUM_LEN {
-            return Err(ParseError::new(ParseErrorKind::InvalidValue));
+            return Err(ParseError::new(ParseErrorKind::InvalidSize {
+                actual: length,
+            }));
         }
 
         Ok(Self {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1310,8 +1310,10 @@ impl<'a, T: Asn1Readable<'a>, const MINIMUM_LEN: usize, const MAXIMUM_LEN: usize
     }
 }
 
-impl<'a, T: Asn1Readable<'a>> Clone for SequenceOf<'a, T> {
-    fn clone(&self) -> SequenceOf<'a, T> {
+impl<'a, T: Asn1Readable<'a>, const MINIMUM_LEN: usize, const MAXIMUM_LEN: usize> Clone
+    for SequenceOf<'a, T, MINIMUM_LEN, MAXIMUM_LEN>
+{
+    fn clone(&self) -> SequenceOf<'a, T, MINIMUM_LEN, MAXIMUM_LEN> {
         SequenceOf {
             parser: self.parser.clone_internal(),
             length: self.length,
@@ -1348,7 +1350,9 @@ impl<'a, T: Asn1Readable<'a> + Hash> Hash for SequenceOf<'a, T> {
     }
 }
 
-impl<'a, T: Asn1Readable<'a> + 'a> SimpleAsn1Readable<'a> for SequenceOf<'a, T> {
+impl<'a, T: Asn1Readable<'a> + 'a, const MIN: usize, const MAX: usize> SimpleAsn1Readable<'a>
+    for SequenceOf<'a, T, MIN, MAX>
+{
     const TAG: Tag = Tag::constructed(0x10);
     #[inline]
     fn parse_data(data: &'a [u8]) -> ParseResult<Self> {
@@ -1356,7 +1360,9 @@ impl<'a, T: Asn1Readable<'a> + 'a> SimpleAsn1Readable<'a> for SequenceOf<'a, T> 
     }
 }
 
-impl<'a, T: Asn1Readable<'a>> Iterator for SequenceOf<'a, T> {
+impl<'a, T: Asn1Readable<'a>, const MINIMUM_LEN: usize, const MAXIMUM_LEN: usize> Iterator
+    for SequenceOf<'a, T, MINIMUM_LEN, MAXIMUM_LEN>
+{
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1372,7 +1378,13 @@ impl<'a, T: Asn1Readable<'a>> Iterator for SequenceOf<'a, T> {
     }
 }
 
-impl<'a, T: Asn1Readable<'a> + Asn1Writable> SimpleAsn1Writable for SequenceOf<'a, T> {
+impl<
+        'a,
+        T: Asn1Readable<'a> + Asn1Writable,
+        const MINIMUM_LEN: usize,
+        const MAXIMUM_LEN: usize,
+    > SimpleAsn1Writable for SequenceOf<'a, T, MINIMUM_LEN, MAXIMUM_LEN>
+{
     const TAG: Tag = Tag::constructed(0x10);
     fn write_data(&self, dest: &mut WriteBuf) -> WriteResult {
         let mut w = Writer::new(dest);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1350,8 +1350,8 @@ impl<'a, T: Asn1Readable<'a> + Hash> Hash for SequenceOf<'a, T> {
     }
 }
 
-impl<'a, T: Asn1Readable<'a> + 'a, const MIN: usize, const MAX: usize> SimpleAsn1Readable<'a>
-    for SequenceOf<'a, T, MIN, MAX>
+impl<'a, T: Asn1Readable<'a> + 'a, const MINIMUM_LEN: usize, const MAXIMUM_LEN: usize>
+    SimpleAsn1Readable<'a> for SequenceOf<'a, T, MINIMUM_LEN, MAXIMUM_LEN>
 {
     const TAG: Tag = Tag::constructed(0x10);
     #[inline]


### PR DESCRIPTION
~~WIP; I need to try this against `cryptography-x509` and see how much additional explicit typing is needed.~~

Adds length limits to `SequenceOf` via const generics + defaults. I can also do `SetOf` in a follow-up.