### PR TITLE
Bump version to 0.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asn1"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Alex Gaynor <alex.gaynor@gmail.com>"]
 repository = "https://github.com/alex/rust-asn1"
 keywords = ["asn1"]
@@ -15,7 +15,7 @@ default = ["std"]
 std = []
 
 [dependencies]
-asn1_derive = { path = "asn1_derive/", version = "0.17.0" }
+asn1_derive = { path = "asn1_derive/", version = "0.18.0" }
 
 [dev-dependencies]
 libc = "0.2.11"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add `asn1` to the `[dependencies]` section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-asn1 = "0.17"
+asn1 = "0.18"
 ```
 
 Builds on Rust 1.59.0 and newer.
@@ -19,7 +19,7 @@ Builds on Rust 1.59.0 and newer.
 `rust-asn1` is compatible with `#![no_std]` environments:
 
 ```toml
-asn1 = { version = "0.17", default-features = false }
+asn1 = { version = "0.18", default-features = false }
 ```
 
 [deps-rs-image]: https://deps.rs/repo/github/alex/rust-asn1/status.svg

--- a/asn1_derive/Cargo.toml
+++ b/asn1_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asn1_derive"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Alex Gaynor <alex.gaynor@gmail.com>"]
 repository = "https://github.com/alex/rust-asn1"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Bump version to 0.18.0 as requested [here](https://github.com/pyca/cryptography/pull/11820#issuecomment-2431728920).