### PR TITLE
Remove type-bounds that aren't needed.

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1269,7 +1269,7 @@ impl SimpleAsn1Writable for SequenceWriter<'_> {
 /// are decoded.
 pub struct SequenceOf<
     'a,
-    T: Asn1Readable<'a>,
+    T,
     const MINIMUM_LEN: usize = 0,
     const MAXIMUM_LEN: usize = { usize::MAX },
 > {
@@ -1412,7 +1412,7 @@ impl<
 
 /// Writes a `SEQUENCE OF` ASN.1 structure from a slice of `T`.
 #[derive(Hash, PartialEq, Eq, Clone)]
-pub struct SequenceOfWriter<'a, T: Asn1Writable, V: Borrow<[T]> = &'a [T]> {
+pub struct SequenceOfWriter<'a, T, V: Borrow<[T]> = &'a [T]> {
     vals: V,
     _phantom: PhantomData<&'a T>,
 }
@@ -1440,7 +1440,7 @@ impl<T: Asn1Writable, V: Borrow<[T]>> SimpleAsn1Writable for SequenceOfWriter<'_
 
 /// Represents an ASN.1 `SET OF`. This is an `Iterator` over values that
 /// are decoded.
-pub struct SetOf<'a, T: Asn1Readable<'a>> {
+pub struct SetOf<'a, T> {
     parser: Parser<'a>,
     _phantom: PhantomData<T>,
 }
@@ -1553,7 +1553,7 @@ impl<'a, T: Asn1Readable<'a> + Asn1Writable> SimpleAsn1Writable for SetOf<'a, T>
 /// Writes an ASN.1 `SET OF` whose contents is a slice of `T`. This type handles
 /// ensuring that the values are properly ordered when written as DER.
 #[derive(Hash, PartialEq, Eq, Clone)]
-pub struct SetOfWriter<'a, T: Asn1Writable, V: Borrow<[T]> = &'a [T]> {
+pub struct SetOfWriter<'a, T, V: Borrow<[T]> = &'a [T]> {
     vals: V,
     _phantom: PhantomData<&'a T>,
 }


### PR DESCRIPTION
It's fine to parametrize a SequenceOf with something that isn't an Asn1 type, because for SequenceOf to be an Asn1 type, T must implement the trait. In practice this is useful with certain GAT patterns.