### PR TITLE
Make `Parser::peek_tag` public

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ $ cargo add asn1 --no-default-features
 
 ## Changelog
 
+### [Unreleased]
+
+#### Added
+
+- `Parser` now exposes a `peek_tag` method that returns the tag of the next 
+   element in the parse, without consuming that element.
+   ([#532](https://github.com/alex/rust-asn1/pull/532))
+
 ### [0.21.0]
 
 #### Changes

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -231,7 +231,8 @@ impl<'a> Parser<'a> {
         Parser::new(self.data)
     }
 
-    pub(crate) fn peek_tag(&mut self) -> Option<Tag> {
+    /// Returns the tag of the next element, without consuming it.
+    pub fn peek_tag(&mut self) -> Option<Tag> {
         let (tag, _) = Tag::from_bytes(self.data).ok()?;
         Some(tag)
     }
@@ -560,6 +561,15 @@ mod tests {
     fn test_parse_extra_data() {
         let result = crate::parse(b"\x00", |_| Ok(()));
         assert_eq!(result, Err(ParseError::new(ParseErrorKind::ExtraData)));
+    }
+
+    #[test]
+    fn test_peek_tag() {
+        let result = crate::parse(b"\x02\x01\x7f", |p| {
+            assert_eq!(p.peek_tag(), Some(Tag::primitive(0x02)));
+            p.read_element::<u8>()
+        });
+        assert_eq!(result, Ok(127));
     }
 
     #[test]


### PR DESCRIPTION
When using the API in dynamic contexts (similarly to https://github.com/alex/rust-asn1/issues/531), some field types can be difficult to read when the type information is not known at compile time.

For example, [`Choice`](https://docs.rs/asn1/latest/asn1/enum.Choice1.html) parsing requires the choice types to be known at compile time. By making `Parser::peek_tag` public, a user can check if the upcoming tag matches any of the expected Choice types, and call the appropriate method to parse it.

cc @woodruffw 