### PR TITLE
Re-add `Parser::read_{explicit,implicit}_element` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ $ cargo add asn1 --no-default-features
 - `Parser` now exposes a `peek_tag` method that returns the tag of the next 
    element in the parse, without consuming that element.
    ([#532](https://github.com/alex/rust-asn1/pull/532))
+- `Parser` now exposes `read_explicit_element` and `read_implicit_element`
+   methods that allow parsing EXPLICIT/IMPLICIT elements when the tag number
+   is not known at compile time.
 
 ### [0.21.0]
 


### PR DESCRIPTION
As discussed in https://github.com/alex/rust-asn1/issues/531, this PR reintroduces the `Parser::read_implicit_element` and `Parser::read_explicit_element` methods that were removed in https://github.com/alex/rust-asn1/commit/74ff00f3a65e9ad52ef78f1f755cbf6f03226242

cc @woodruffw @alex 