### PR TITLE
Fix CHOICE docs to match current API

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1277,8 +1277,8 @@ macro_rules! declare_choice {
         ///
         /// If you need more variants than are provided, please file an issue
         /// or submit a pull request! Arbitrary numbers of variants are
-        /// supported by the `#[derive(asn1::Asn1Readable)]` and
-        /// `#[derive(asn1::Asn1Writable)]` APIs.
+        /// supported by the `#[derive(asn1::Asn1Read)]` and
+        /// `#[derive(asn1::Asn1Write)]` APIs.
         #[derive(Debug, PartialEq, Eq)]
         pub enum $count<
             $($number,)*


### PR DESCRIPTION
I think these should be `Asn1Read` and `Asn1Write`, as used in [here](https://github.com/pyca/cryptography/blob/be6c53dd03172dde6af2de775a9d8e65e6b60fb0/src/rust/cryptography-x509/src/name.rs#L52-L83)

cc @woodruffw 