### PR TITLE
remove utility functions that were never needed

### DIFF
--- a/asn1_derive/src/lib.rs
+++ b/asn1_derive/src/lib.rs
@@ -700,7 +700,7 @@ fn generate_read_element(
             }
         }
         OpType::DefinedBy(ident) => quote::quote! {
-            asn1::read_defined_by(#ident, p)#add_error_location?
+            asn1::Asn1DefinedByReadable::parse(#ident, p)#add_error_location?
         },
     };
     if let Some(default) = default {
@@ -932,7 +932,7 @@ fn generate_write_element(
         OpType::Regular => {
             if let Some(defined_by_marker_read) = defined_by_marker_origin {
                 quote::quote! {
-                    w.write_element(asn1::writable_defined_by_item(#defined_by_marker_read))?;
+                    w.write_element(asn1::Asn1DefinedByWritable::item(#defined_by_marker_read))?;
                 }
             } else {
                 quote::quote! {
@@ -941,7 +941,7 @@ fn generate_write_element(
             }
         }
         OpType::DefinedBy(_) => quote::quote! {
-            asn1::write_defined_by(#field_read, &mut w)?;
+            asn1::Asn1DefinedByWritable::write(#field_read, &mut w)?;
         },
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,33 +206,6 @@ pub const fn explicit_tag(tag: u32) -> Tag {
     Tag::new(tag, tag::TagClass::ContextSpecific, true)
 }
 
-/// This API is public so that it may be used from macros, but should not be
-/// considered a part of the supported API surface.
-#[doc(hidden)]
-pub fn read_defined_by<'a, T: Asn1Readable<'a>, U: Asn1DefinedByReadable<'a, T>>(
-    v: T,
-    p: &mut Parser<'a>,
-) -> ParseResult<U> {
-    U::parse(v, p)
-}
-
-/// This API is public so that it may be used from macros, but should not be
-/// considered a part of the supported API surface.
-#[doc(hidden)]
-pub fn write_defined_by<T: Asn1Writable, U: Asn1DefinedByWritable<T>>(
-    v: &U,
-    w: &mut Writer<'_>,
-) -> WriteResult {
-    v.write(w)
-}
-
-/// This API is public so that it may be used from macros, but should not be
-/// considered a part of the supported API surface.
-#[doc(hidden)]
-pub fn writable_defined_by_item<T: Asn1Writable, U: Asn1DefinedByWritable<T>>(v: &U) -> &T {
-    v.item()
-}
-
 /// Utility for use in `asn1_derive`. Not considered part of the public API.
 #[doc(hidden)]
 pub trait OptionExt {


### PR DESCRIPTION
we can just invoke the trait directly, its simpler