### PR TITLE
fixes #340 -- allow types to provide their length to reduce allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ $ cargo add asn1 --no-default-features
 
 ### Unreleased
 
+#### Added
+
+- Added `Asn1Writable::encoded_length`, `SimpleAsn1Writable::data_length`, and
+  `Asn1DefinedByWritable::encoded_length`. Implementing these functions reduces
+  the number of re-allocations required when writing.
+
 #### Changes
 
 - Updated MSRV to 1.74.0.

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -135,6 +135,17 @@ impl Tag {
     pub fn value(self) -> u32 {
         self.value
     }
+
+    /// Get the number of bytes needed to encode this tag.
+    pub(crate) fn encoded_length(self) -> usize {
+        if self.value >= 0x1f {
+            // Long form: 1 byte for the initial tag byte + base128 encoding of the value
+            1 + crate::base128::base128_length(self.value.into())
+        } else {
+            // Short form: 1 byte
+            1
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
shows a 60% improvement at `serialize_basic_struct/size_10000` (there's also a smaller performance improvement for the parse benchmarks, but there's no valid reason for those to occur, so I'm ignoring)