### PR TITLE
Batch 4: Add data_length implementations

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1494,6 +1494,10 @@ impl SimpleAsn1Writable for Sequence<'_> {
     fn write_data(&self, data: &mut WriteBuf) -> WriteResult {
         data.push_slice(self.data)
     }
+
+    fn data_length(&self) -> Option<usize> {
+        Some(self.data.len())
+    }
 }
 
 /// Writes an ASN.1 `SEQUENCE` using a callback that writes the inner
@@ -1688,6 +1692,11 @@ impl<T: Asn1Writable, V: Borrow<[T]>> SimpleAsn1Writable for SequenceOfWriter<'_
 
         Ok(())
     }
+
+    fn data_length(&self) -> Option<usize> {
+        let vals = self.vals.borrow();
+        vals.iter().map(|v| v.encoded_length()).sum()
+    }
 }
 
 /// Represents an ASN.1 `SET OF`. This is an `Iterator` over values that
@@ -1851,6 +1860,11 @@ impl<T: Asn1Writable, V: Borrow<[T]>> SimpleAsn1Writable for SetOfWriter<'_, T, 
         }
 
         Ok(())
+    }
+
+    fn data_length(&self) -> Option<usize> {
+        let vals = self.vals.borrow();
+        vals.iter().map(|v| v.encoded_length()).sum()
     }
 }
 


### PR DESCRIPTION
- Add data_length to Sequence<'_> (returns data slice length)
- Add data_length to SequenceOfWriter<'_, T, V> (sums encoded_length of all elements)
- Add data_length to SetOfWriter<'_, T, V> (sums encoded_length of all elements)