### PR TITLE
Re-add `Writer::write_{explicit,implicit}_element` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ $ cargo add asn1 --no-default-features
 
 ### Unreleased
 
+#### Added
+
+- `Writer` now exposes `write_explicit_element` and `write_implicit_element`
+   methods that allow encoding EXPLICIT/IMPLICIT elements when the tag number
+   is not known at compile time.
+
 ### [0.22.0]
 
 #### Added


### PR DESCRIPTION
This PR reintroduces the `Writer::write_implicit_element` and `Writer::write_explicit_element` methods that were removed in https://github.com/alex/rust-asn1/pull/500/files

The only change is that `write_tlv()` is now called passing the precomputed length of the value to be written (using `Asn1Writable::encoded_length` for `EXPLICIT` values and `SimpleAsn1Writable::data_length` for `IMPLICIT` values).