### PR TITLE
Allow custom write errors

### DIFF
--- a/asn1_derive/src/lib.rs
+++ b/asn1_derive/src/lib.rs
@@ -63,10 +63,25 @@ fn derive_asn1_read_expand(input: syn::DeriveInput) -> syn::Result<proc_macro2::
     Ok(expanded)
 }
 
-#[proc_macro_derive(Asn1Write, attributes(explicit, implicit, default, defined_by))]
+fn get_err_attribute(input: &syn::DeriveInput) -> syn::Result<syn::Type> {
+    for attr in &input.attrs {
+        if attr.path().is_ident("error_type") {
+            let err_type: syn::Type = attr.parse_args()?;
+            return Ok(err_type);
+        }
+    }
+    return Err(syn::Error::new_spanned(
+        input,
+        "Error type for asn1::Asn1Writable/Asn1DefinedByWritable implementation was not specified",
+    ));
+}
+
+#[proc_macro_derive(
+    Asn1Write,
+    attributes(explicit, implicit, default, defined_by, error_type)
+)]
 pub fn derive_asn1_write(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
-
     derive_asn1_write_expand(input)
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
@@ -75,11 +90,20 @@ pub fn derive_asn1_write(input: proc_macro::TokenStream) -> proc_macro::TokenStr
 fn derive_asn1_write_expand(mut input: syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let name = &input.ident;
     let fields = all_field_types(&input.data, false, &input.generics)?;
+    let err_type = get_err_attribute(&input)?;
     add_bounds(
+        &mut input.generics,
+        fields.clone(),
+        syn::parse_quote!(asn1::Asn1Writable),
+        syn::parse_quote!(asn1::Asn1DefinedByWritable<asn1::ObjectIdentifier>),
+        true,
+    );
+    add_write_error_bounds(
         &mut input.generics,
         fields,
         syn::parse_quote!(asn1::Asn1Writable),
         syn::parse_quote!(asn1::Asn1DefinedByWritable<asn1::ObjectIdentifier>),
+        err_type.clone(),
         true,
     );
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
@@ -89,8 +113,9 @@ fn derive_asn1_write_expand(mut input: syn::DeriveInput) -> syn::Result<proc_mac
             let (write_block, data_length_block) = generate_struct_write_block(&data)?;
             quote::quote! {
                 impl #impl_generics asn1::SimpleAsn1Writable for #name #ty_generics #where_clause {
+                    type Error = #err_type;
                     const TAG: asn1::Tag = <asn1::SequenceWriter as asn1::SimpleAsn1Writable>::TAG;
-                    fn write_data(&self, dest: &mut asn1::WriteBuf) -> asn1::WriteResult {
+                    fn write_data(&self, dest: &mut asn1::WriteBuf) -> Result<(), Self::Error> {
                         #write_block
 
                         Ok(())
@@ -106,7 +131,8 @@ fn derive_asn1_write_expand(mut input: syn::DeriveInput) -> syn::Result<proc_mac
             let (write_block, length_block) = generate_enum_write_block(name, &data)?;
             quote::quote! {
                 impl #impl_generics asn1::Asn1Writable for #name #ty_generics #where_clause {
-                    fn write(&self, w: &mut asn1::Writer) -> asn1::WriteResult {
+                    type Error = #err_type;
+                    fn write(&self, w: &mut asn1::Writer) -> Result<(), Self::Error> {
                         #write_block
                     }
                     fn encoded_length(&self) -> Option<usize> {
@@ -115,7 +141,8 @@ fn derive_asn1_write_expand(mut input: syn::DeriveInput) -> syn::Result<proc_mac
                 }
 
                 impl #impl_generics asn1::Asn1Writable for &#name #ty_generics #where_clause {
-                    fn write(&self, w: &mut asn1::Writer) -> asn1::WriteResult {
+                    type Error = #err_type;
+                    fn write(&self, w: &mut asn1::Writer) -> Result<(), Self::Error> {
                         (*self).write(w)
                     }
 
@@ -256,7 +283,7 @@ fn derive_asn1_defined_by_read_expand(
     })
 }
 
-#[proc_macro_derive(Asn1DefinedByWrite, attributes(default, defined_by))]
+#[proc_macro_derive(Asn1DefinedByWrite, attributes(default, defined_by, error_type))]
 pub fn derive_asn1_defined_by_write(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
 
@@ -270,11 +297,20 @@ fn derive_asn1_defined_by_write_expand(
 ) -> syn::Result<proc_macro2::TokenStream> {
     let name = &input.ident;
     let fields = all_field_types(&input.data, true, &input.generics)?;
+    let err_type = get_err_attribute(&input)?;
     add_bounds(
+        &mut input.generics,
+        fields.clone(),
+        syn::parse_quote!(asn1::Asn1Writable),
+        syn::parse_quote!(asn1::Asn1DefinedByWritable<asn1::ObjectIdentifier>),
+        true,
+    );
+    add_write_error_bounds(
         &mut input.generics,
         fields,
         syn::parse_quote!(asn1::Asn1Writable),
         syn::parse_quote!(asn1::Asn1DefinedByWritable<asn1::ObjectIdentifier>),
+        err_type.clone(),
         true,
     );
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
@@ -329,13 +365,14 @@ fn derive_asn1_defined_by_write_expand(
 
     Ok(quote::quote! {
         impl #impl_generics asn1::Asn1DefinedByWritable<asn1::ObjectIdentifier> for #name #ty_generics #where_clause {
+            type Error = #err_type;
             fn item(&self) -> &asn1::ObjectIdentifier {
                 match self {
                     #(#item_blocks)*
                 }
             }
 
-            fn write(&self, w: &mut asn1::Writer) -> asn1::WriteResult {
+            fn write(&self, w: &mut asn1::Writer) -> Result((), Self::Error) {
                 match self {
                     #(#write_blocks)*
                 }
@@ -601,6 +638,109 @@ fn add_bounds(
                     p
                 },
             }))
+    }
+}
+
+fn add_write_error_bounds(
+    generics: &mut syn::Generics,
+    field_types: Vec<(syn::Type, OpType, bool)>,
+    bound: syn::TypeParamBound,
+    defined_by_bound: syn::TypeParamBound,
+    write_error_type: syn::Type,
+    add_ref: bool,
+) {
+    let where_clause = if field_types.is_empty() {
+        return;
+    } else {
+        generics
+            .where_clause
+            .get_or_insert_with(|| syn::WhereClause {
+                where_token: Default::default(),
+                predicates: syn::punctuated::Punctuated::new(),
+            })
+    };
+    for (f, op_type, has_default) in &field_types {
+        let (field_err_type_bound, simple_writable_predicate): (
+            syn::TypeParamBound,
+            Option<syn::WherePredicate>,
+        ) = match (op_type, add_ref) {
+            (OpType::Regular, _) => (syn::parse_quote!(From<<#f as #bound>::Error>), None),
+            (OpType::DefinedBy(_), _) => (
+                syn::parse_quote!(From<<#f as #defined_by_bound>::Error>),
+                None,
+            ),
+            (OpType::Implicit(OpTypeArgs { value, required }), false) => {
+                if *required || *has_default {
+                    (
+                        syn::parse_quote!(From<<asn1::Implicit::<#f, #value> as #bound>::Error>),
+                        Some(syn::parse_quote!(#f: asn1::SimpleAsn1Writable)),
+                    )
+                } else {
+                    (
+                        syn::parse_quote!(From<<asn1::Implicit::<<#f as asn1::OptionExt>::T, #value> as #bound>::Error>),
+                        Some(
+                            syn::parse_quote!(<#f as asn1::OptionExt>::T: asn1::SimpleAsn1Writable),
+                        ),
+                    )
+                }
+            }
+            (OpType::Implicit(OpTypeArgs { value, required }), true) => {
+                if *required || *has_default {
+                    (
+                        syn::parse_quote!(for<'asn1_internal> From<<asn1::Implicit::<&'asn1_internal #f, #value> as #bound>::Error>),
+                        Some(syn::parse_quote!(#f: asn1::SimpleAsn1Writable)),
+                    )
+                } else {
+                    (
+                        syn::parse_quote!(for<'asn1_internal> From<<asn1::Implicit::<&'asn1_internal <#f as asn1::OptionExt>::T, #value> as #bound>::Error>),
+                        Some(
+                            syn::parse_quote!(<#f as asn1::OptionExt>::T: asn1::SimpleAsn1Writable),
+                        ),
+                    )
+                }
+            }
+            (OpType::Explicit(OpTypeArgs { value, required }), false) => {
+                if *required || *has_default {
+                    (
+                        syn::parse_quote!(From<<asn1::Explicit::<#f, #value> as #bound>::Error>),
+                        None,
+                    )
+                } else {
+                    (
+                        syn::parse_quote!(From<<asn1::Explicit::<<#f as asn1::OptionExt>::T, #value> as #bound>::Error>),
+                        None,
+                    )
+                }
+            }
+            (OpType::Explicit(OpTypeArgs { value, required }), true) => {
+                if *required || *has_default {
+                    (
+                        syn::parse_quote!(for<'asn1_internal> From<<asn1::Explicit::<&'asn1_internal #f, #value> as #bound>::Error>),
+                        None,
+                    )
+                } else {
+                    (
+                        syn::parse_quote!(for<'asn1_internal> From<<asn1::Explicit::<&'asn1_internal <#f as asn1::OptionExt>::T, #value> as #bound>::Error>),
+                        None,
+                    )
+                }
+            }
+        };
+        where_clause
+            .predicates
+            .push(syn::WherePredicate::Type(syn::PredicateType {
+                lifetimes: None,
+                bounded_ty: write_error_type.clone(),
+                colon_token: Default::default(),
+                bounds: {
+                    let mut p = syn::punctuated::Punctuated::new();
+                    p.push(field_err_type_bound);
+                    p
+                },
+            }));
+        if let Some(pred) = simple_writable_predicate {
+            where_clause.predicates.push(pred);
+        }
     }
 }
 

--- a/examples/no_std.rs
+++ b/examples/no_std.rs
@@ -17,11 +17,13 @@ fn main() {
     };
 
     let computed = asn1::write(|w| {
-        w.write_element(&asn1::SequenceWriter::new(&|w: &mut asn1::Writer| {
-            w.write_element(&1i64)?;
-            w.write_element(&3i64)?;
-            Ok(())
-        }))
+        w.write_element(&asn1::SequenceWriter::<asn1::WriteError>::new(
+            &|w: &mut asn1::Writer| {
+                w.write_element(&1i64)?;
+                w.write_element(&3i64)?;
+                Ok(())
+            },
+        ))
     })
     .unwrap();
     unsafe {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -112,7 +112,7 @@ impl Writer<'_> {
 
     /// Writes a single element to the output.
     #[inline]
-    pub fn write_element<T: Asn1Writable>(&mut self, val: &T) -> WriteResult {
+    pub fn write_element<T: Asn1Writable>(&mut self, val: &T) -> Result<(), T::Error> {
         if let Some(len) = val.encoded_length() {
             self.buf.reserve_additional(len)?;
         }
@@ -126,12 +126,12 @@ impl Writer<'_> {
     /// If `content_length` is provided, it reduces the number of
     /// re-allocations required.
     #[inline]
-    pub fn write_tlv<F: FnOnce(&mut WriteBuf) -> WriteResult>(
+    pub fn write_tlv<E: From<WriteError>, F: FnOnce(&mut WriteBuf) -> Result<(), E>>(
         &mut self,
         tag: Tag,
         content_length: Option<usize>,
         body: F,
-    ) -> WriteResult {
+    ) -> Result<(), E> {
         tag.write_bytes(self.buf)?;
 
         match content_length {
@@ -157,7 +157,7 @@ impl Writer<'_> {
                 self.buf.push_byte(0)?;
                 let start_len = self.buf.len();
                 body(self.buf)?;
-                self.insert_length(start_len)
+                Ok(self.insert_length(start_len)?)
             }
         }
     }
@@ -181,7 +181,11 @@ impl Writer<'_> {
     }
 
     /// This is an alias for `write_element::<Explicit<T, tag>>`.
-    pub fn write_explicit_element<T: Asn1Writable>(&mut self, val: &T, tag: u32) -> WriteResult {
+    pub fn write_explicit_element<T: Asn1Writable>(
+        &mut self,
+        val: &T,
+        tag: u32,
+    ) -> Result<(), T::Error> {
         let tag = crate::explicit_tag(tag);
         self.write_tlv(tag, val.encoded_length(), |dest| {
             Writer::new(dest).write_element(val)
@@ -193,7 +197,7 @@ impl Writer<'_> {
         &mut self,
         val: &T,
         tag: u32,
-    ) -> WriteResult {
+    ) -> Result<(), T::Error> {
         let tag = crate::implicit_tag(tag, T::TAG);
         self.write_tlv(tag, val.data_length(), |dest| val.write_data(dest))
     }
@@ -202,7 +206,9 @@ impl Writer<'_> {
 /// Constructs a writer and invokes a callback which writes ASN.1 elements into
 /// the writer, then returns the generated DER bytes.
 #[inline]
-pub fn write<F: Fn(&mut Writer<'_>) -> WriteResult>(f: F) -> WriteResult<Vec<u8>> {
+pub fn write<E: From<WriteError>, F: Fn(&mut Writer<'_>) -> Result<(), E>>(
+    f: F,
+) -> Result<Vec<u8>, E> {
     let mut v = WriteBuf::new(vec![]);
     let mut w = Writer::new(&mut v);
     f(&mut w)?;
@@ -212,7 +218,7 @@ pub fn write<F: Fn(&mut Writer<'_>) -> WriteResult>(f: F) -> WriteResult<Vec<u8>
 /// Writes a single top-level ASN.1 element, returning the generated DER bytes.
 /// Most often this will be used where `T` is a type with
 /// `#[derive(asn1::Asn1Write)]`.
-pub fn write_single<T: Asn1Writable>(v: &T) -> WriteResult<Vec<u8>> {
+pub fn write_single<T: Asn1Writable>(v: &T) -> Result<Vec<u8>, T::Error> {
     write(|w| w.write_element(v))
 }
 
@@ -238,6 +244,7 @@ mod tests {
     fn assert_writes<T>(data: &[(T, &[u8])])
     where
         T: Asn1Writable,
+        <T as Asn1Writable>::Error: std::fmt::Debug,
     {
         for (val, expected) in data {
             let result = write_single(val).unwrap();
@@ -742,8 +749,10 @@ mod tests {
         );
 
         assert_eq!(
-            write(|w| { w.write_implicit_element(&SequenceWriter::new(&|_w| { Ok(()) }), 2) })
-                .unwrap(),
+            write(|w| {
+                w.write_implicit_element(&SequenceWriter::<WriteError>::new(&|_w| Ok(())), 2)
+            })
+            .unwrap(),
             b"\xa2\x00"
         );
     }

--- a/tests/roundtrip_tests.rs
+++ b/tests/roundtrip_tests.rs
@@ -1,6 +1,9 @@
 fn assert_roundtrips<T>(i: T)
 where
-    for<'a> T: asn1::Asn1Writable + asn1::Asn1Readable<'a> + std::fmt::Debug + PartialEq,
+    for<'a> T: asn1::Asn1Writable<Error = asn1::WriteError>
+        + asn1::Asn1Readable<'a>
+        + std::fmt::Debug
+        + PartialEq,
 {
     let result = asn1::write_single::<T>(&i).unwrap();
     let parsed = asn1::parse_single::<T>(&result).unwrap();


### PR DESCRIPTION
Attempt at implementing custom error types for encoding, as per the comment in https://github.com/alex/rust-asn1/pull/562#issuecomment-3016693464

This PR:
- Adds an associated type to the `Asn1Writable`, `SimpleAsn1Writable` and `Asn1DefinedByWritable` traits called `Error`, which specifies the error type for the associated `write` functions
- Adds a helper attribute called `error_type` to the derive macro `Asn1Write` (which will populate the associated type mentioned above)
- Changes the `Asn1Write` derive macro, adding more trait bounds to the derived `SimpleAsn1Writable` implementation for a type `T`.
  - The new trait bounds restrict the associated error types of each field of `T` to be convertible to `T::Error`. For example: `T::Error: From<FieldOfT::Error>`. This is so that an error that happens while writing any of the fields of `T` can be converted to the error type associated with `T`.

However, after adding these new bounds, the compiler now complains about the derived `SimpleAsn1Writable` implementation for `T`, for the cases where there are fields present maked as IMPLICIT and OPTIONAL.

```rust
error[E0277]: the trait bound `<T as test_perfect_derive::X>::Type: SimpleAsn1Writable` is not satisfied
   --> tests/derive_test.rs:898:30
    |
898 |     #[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Debug, Eq)]
    |                              ^^^^^^^^^^^^^^^ the trait `SimpleAsn1Writable` is not implemented for `<T as test_perfect_derive::X>::Type`
    |
    = note: required for `&'asn1_internal <T as test_perfect_derive::X>::Type` to implement `for<'asn1_internal> SimpleAsn1Writable`
    = note: this error originates in the derive macro `asn1::Asn1Write` (in Nightly builds, run with -Z macro-backtrace for more info)
```

when processing this type in `derive_test:898`:
```rust
    #[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Debug, Eq)]
    #[error_type(asn1::WriteError)]
    struct TaggedOptionalFields<T: X> {
        #[implicit(1)]
        a: Option<T::Type>,
        #[explicit(2)]
        b: Option<T::Type>,
    }
```

I don't quite understand why this is needed now (and not before), and trying to fix it by adding another bound so that `X: SimpleAsn1Writable` for the `X` in `Implicit<X>` didn't work.

I'm opening this as a draft for reference and discussion.