### PR TITLE
Fix ordering check when encoding SET

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ $ cargo add asn1 --no-default-features
 
 ### Unreleased
 
+#### Fixes
+
+- Fixed encoding a `Set` with absent optional fields incorrectly
+  returning `InvalidSetOrdering`
+
 ### [0.24.0]
 
 #### Added

--- a/src/types.rs
+++ b/src/types.rs
@@ -2038,6 +2038,11 @@ impl<'a> SetElementWriter<'a> {
         self.writer.write_element(val)?;
         let end = self.writer.buf.len();
 
+        // Nothing was written (e.g. Option::None), skip ordering check.
+        if start == end {
+            return Ok(());
+        }
+
         if let Some(prev_start) = self.prev_start {
             let prev = &self.writer.buf.as_slice()[prev_start..start];
             let curr = &self.writer.buf.as_slice()[start..end];

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -848,6 +848,28 @@ mod tests {
             }),
             Err(WriteError::InvalidSetOrdering)
         );
+
+        assert_eq!(
+            write(|w| {
+                w.write_element(&SetWriter::new(&|w: &mut SetElementWriter<'_>| {
+                    w.write_element(&true)?;
+                    w.write_element(&Some(1i64))
+                }))
+            })
+            .unwrap(),
+            b"\x31\x06\x01\x01\xff\x02\x01\x01"
+        );
+
+        assert_eq!(
+            write(|w| {
+                w.write_element(&SetWriter::new(&|w: &mut SetElementWriter<'_>| {
+                    w.write_element(&true)?;
+                    w.write_element(&Option::<i64>::None)
+                }))
+            })
+            .unwrap(),
+            b"\x31\x03\x01\x01\xff"
+        );
     }
 
     #[test]


### PR DESCRIPTION
When encoding `SET` fields, we keep track of the last written field to see if the current field is correctly ordered relative to it. 

However, in some cases a field is not encoded (for example, for absent optional values). In those cases, we shouldn't check the ordering.