### PR TITLE
Add `Tlv::tag_bytes()` public method

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,15 @@ $ cargo add asn1 --no-default-features
 
 ### Unreleased
 
+#### Added
+
+- Added `Tlv::tag_bytes()` wich return the DER-encoded bytes
+  of the tag portion of a TLV.
+
 #### Fixes
 
 - Fixed encoding a `Set` with absent optional fields incorrectly
-  returning `InvalidSetOrdering`
+  returning `InvalidSetOrdering`. ([#607](https://github.com/alex/rust-asn1/pull/607))
 
 ### [0.24.0]
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -210,6 +210,10 @@ impl<'a> Tlv<'a> {
     pub fn tag(&self) -> Tag {
         self.tag
     }
+    /// The DER encoded tag.
+    pub fn tag_bytes(&self) -> &'a [u8] {
+        &self.full_data[..self.tag.encoded_length()]
+    }
     /// The value portion of the TLV.
     pub fn data(&self) -> &'a [u8] {
         self.data
@@ -2441,6 +2445,15 @@ mod tests {
     #[test]
     fn test_visiblestring_as_str() {
         assert_eq!(VisibleString::new("abc").unwrap().as_str(), "abc");
+    }
+
+    #[test]
+    fn test_tlv_tag_bytes() {
+        let tlv = parse_single::<Tlv<'_>>(b"\x01\x03abc").unwrap();
+        assert_eq!(tlv.tag_bytes(), b"\x01");
+
+        let tlv_long = parse_single::<Tlv<'_>>(b"\x1f\x1f\x03abc").unwrap();
+        assert_eq!(tlv_long.tag_bytes(), b"\x1f\x1f");
     }
 
     #[test]


### PR DESCRIPTION
With this, https://github.com/alex/rust-asn1/pull/596 should be unnecessary.