### PR TITLE
Add benchmark variants with a larger (4-byte) encoded integer

### DIFF
--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -8,24 +8,29 @@ struct BasicStruct<'a> {
     octet_string_field: &'a [u8],
 }
 
+// 42 encodes as a single byte, 0x7FFF_FFFF encodes as 4 bytes.
+const INTEGER_VALUES: [(&str, u64); 2] = [("small", 42), ("large", 0x7FFF_FFFF)];
+
 fn bench_parse_basic_struct(c: &mut Criterion) {
     let mut group = c.benchmark_group("parse_basic_struct");
 
     for size in [0, 100, 10000] {
-        let octet_data = vec![0x42u8; size];
-        let test_data = asn1::write_single(&BasicStruct {
-            integer_field: 42,
-            bool_field: true,
-            octet_string_field: &octet_data,
-        })
-        .unwrap();
-
-        group.bench_with_input(format!("size_{size}"), &size, |b, _| {
-            b.iter(|| {
-                let result = asn1::parse_single::<BasicStruct>(black_box(&test_data)).unwrap();
-                black_box(result)
+        for (int_name, int_value) in INTEGER_VALUES {
+            let octet_data = vec![0x42u8; size];
+            let test_data = asn1::write_single(&BasicStruct {
+                integer_field: int_value,
+                bool_field: true,
+                octet_string_field: &octet_data,
             })
-        });
+            .unwrap();
+
+            group.bench_with_input(format!("size_{size}_int_{int_name}"), &size, |b, _| {
+                b.iter(|| {
+                    let result = asn1::parse_single::<BasicStruct>(black_box(&test_data)).unwrap();
+                    black_box(result)
+                })
+            });
+        }
     }
     group.finish();
 }
@@ -34,19 +39,21 @@ fn bench_serialize_basic_struct(c: &mut Criterion) {
     let mut group = c.benchmark_group("serialize_basic_struct");
 
     for size in [0, 100, 10000] {
-        let octet_data = vec![0x42u8; size];
-        let test_struct = BasicStruct {
-            integer_field: 42,
-            bool_field: true,
-            octet_string_field: &octet_data,
-        };
+        for (int_name, int_value) in INTEGER_VALUES {
+            let octet_data = vec![0x42u8; size];
+            let test_struct = BasicStruct {
+                integer_field: int_value,
+                bool_field: true,
+                octet_string_field: &octet_data,
+            };
 
-        group.bench_with_input(format!("size_{size}"), &size, |b, _| {
-            b.iter(|| {
-                let result = asn1::write_single(black_box(&test_struct)).unwrap();
-                black_box(result)
-            })
-        });
+            group.bench_with_input(format!("size_{size}_int_{int_name}"), &size, |b, _| {
+                b.iter(|| {
+                    let result = asn1::write_single(black_box(&test_struct)).unwrap();
+                    black_box(result)
+                })
+            });
+        }
     }
     group.finish();
 }


### PR DESCRIPTION
The parse and serialize benchmarks previously always used `integer_field: 42`, which encodes to a single content byte in DER. This adds an integer-size dimension to both benchmark groups: each octet-string size (0, 100, 10000) now also runs with `0x7FFF_FFFF`, which encodes to 4 bytes.

Benchmark names are now of the form `parse_basic_struct/size_100_int_large`, giving 12 variants total.

Verified with `cargo bench --bench basic -- --test` that all variants compile and run.

https://claude.ai/code/session_01WU6Tx8n3m1P61T4Bqny1kT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WU6Tx8n3m1P61T4Bqny1kT)_