### PR TITLE
Upgrade to syn 3

### DIFF
--- a/asn1_derive/Cargo.toml
+++ b/asn1_derive/Cargo.toml
@@ -13,6 +13,6 @@ rust-version = "1.83.0"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.69"
-quote = "1.0.28"
-syn = "2.0.21"
+proc-macro2 = "1.0.91"
+quote = "1.0.35"
+syn = "3.0.0"

--- a/asn1_derive/src/lib.rs
+++ b/asn1_derive/src/lib.rs
@@ -470,7 +470,7 @@ fn add_field_types(
 fn type_contains_generic_param(t: &syn::Type, generic_params: &[syn::Ident]) -> bool {
     match t {
         syn::Type::Array(v) => type_contains_generic_param(&v.elem, generic_params),
-        syn::Type::BareFn(_) => todo!("BareFn"),
+        syn::Type::FnPtr(_) => todo!("FnPtr"),
         syn::Type::Group(v) => type_contains_generic_param(&v.elem, generic_params),
         syn::Type::ImplTrait(_) => todo!("ImplTrait"),
         syn::Type::Infer(_) => false,
@@ -621,6 +621,7 @@ fn add_bounds(
         where_clause
             .predicates
             .push(syn::WherePredicate::Type(syn::PredicateType {
+                attrs: vec![],
                 lifetimes: None,
                 bounded_ty,
                 colon_token: Default::default(),


### PR DESCRIPTION
Bumps `syn` from 2.0.21 to 3.0.0 in `asn1_derive`.

The `proc-macro2` and `quote` floors are raised to 1.0.91 and 1.0.35 respectively to match syn 3.0.0's declared minimums — without this, the `-Z direct-minimal-versions` CI job would fail to resolve.

Code changes required for syn 3's API:
- `Type::BareFn` was renamed to `Type::FnPtr` (in the `todo!()` arm of `type_contains_generic_param`)
- `syn::PredicateType` gained an `attrs` field

syn 3's MSRV is 1.71, comfortably below this crate's 1.83, so no MSRV change.

Verified locally: `cargo test --workspace` (204 tests), `cargo clippy --workspace --all-targets [--all-features] -- -D warnings`, `cargo fmt --check`, and `cargo check/test --workspace -Z direct-minimal-versions` on nightly (resolves syn 3.0.0 / proc-macro2 1.0.91 / quote 1.0.35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwQnkVpL9QiPe2PDWBmEd7

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwQnkVpL9QiPe2PDWBmEd7)_